### PR TITLE
[#51] 릴리즈 노트 자동 생성 워크플로우 추가

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,38 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+tag-prefix: 'v'
+
+categories:
+  - title: '✨ 새로운 기능이 추가되었어요'
+    semver-increment: minor
+    when:
+      labels:
+        - '✨ feature'
+  - title: '🐞 자잘한 버그를 수정했어요'
+    semver-increment: patch
+    when:
+      labels:
+        - '🔧 fix'
+        - '🔥 hotfix'
+  - title: '🛠 코드를 개선했어요'
+    semver-increment: patch
+    when:
+      labels:
+        - '⚙️ chore'
+        - '🔨 refactor'
+        - '✅ test'
+        - '📃 docs'
+  - title: '기타 변경'
+    semver-increment: patch
+
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+change-title-escapes: '\<*_&'
+sort-by: merged_at
+sort-direction: descending
+
+template: |
+  ## 이번 버전의 변경사항은 아래와 같아요
+
+  $CHANGES
+
+no-changes-template: '변경사항이 없어요.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release with Notes
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, e.g. 1.0.0"
+        required: true
+        type: string
+      target_branch:
+        description: "Branch to release from"
+        required: true
+        default: "main"
+        type: string
+      release_mode:
+        description: "Release mode: latest publishes immediately, draft stays unpublished"
+        required: true
+        default: "latest"
+        type: choice
+        options:
+          - latest
+          - draft
+
+run-name: "${{ inputs.release_mode }} v${{ inputs.version }} from ${{ inputs.target_branch }}"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-with-notes-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create ${{ inputs.release_mode }} release with generated notes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION"
+            echo "Use a SemVer-like value such as 1.0.0."
+            exit 1
+          fi
+
+      - name: Create ${{ inputs.release_mode }} release with generated notes
+        uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml
+          version: ${{ inputs.version }}
+          name: v${{ inputs.version }}
+          tag: v${{ inputs.version }}
+          commitish: ${{ inputs.target_branch }}
+          publish: ${{ inputs.release_mode == 'latest' }}
+          latest: ${{ inputs.release_mode == 'latest' }}


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [x] Chore
- [ ] Docs
- [ ] Test

## ✏️ 변경 사항

- `workflow_dispatch`에서 버전, 대상 브랜치, 공개 방식을 입력받는 릴리즈 워크플로우를 추가했습니다.
- 입력한 버전이 SemVer 형식인지 확인한 뒤 Release Drafter v7으로 GitHub Release와 릴리즈 노트를 생성합니다.
- `latest`는 즉시 공개하고 `draft`는 초안으로 보관하도록 구성했습니다.
- 저장소의 `✨ feature`, `🔧 fix`, `🔥 hotfix`, `⚙️ chore`, `🔨 refactor`, `✅ test`, `📃 docs` 라벨에 맞춰 변경사항을 분류합니다.
- 각 카테고리의 버전 증가 기준과 최근 병합 순 정렬을 설정했습니다.

## 🚨 관련 이슈

- close #51

## 🎨 스크린샷

UI 변경이 없어 스크린샷은 생략합니다.

## ✅ 체크리스트

- [x] 저장소의 기존 라벨과 PR 형식을 확인했습니다.
- [x] YAML 문법과 공백 오류를 검사했습니다.
- [x] Release Drafter v7의 액션 입력값 및 설정 스키마와 대조했습니다.
- [ ] Assignee와 Reviewer를 지정했습니다.

## 🔥 추가 설명

- 현재는 Actions 화면에서 직접 실행하는 수동 워크플로우입니다.
- `main` push 트리거는 전달받은 설정대로 주석 상태로 유지했습니다.
- 릴리즈 실행 시 `1.0.0`과 같은 버전, 릴리즈 대상 브랜치, `latest` 또는 `draft`를 선택할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 버전과 대상 브랜치, 릴리스 모드를 지정해 수동으로 릴리스를 생성할 수 있습니다.
  - 릴리스 버전 형식을 자동으로 확인합니다.
  - 변경사항이 카테고리별로 정리된 릴리스 노트를 자동 생성합니다.
  - 릴리스를 초안으로 저장하거나 즉시 게시할 수 있으며, 최신 릴리스로 표시할 수 있습니다.
  - 변경사항이 없을 때도 일관된 형식의 릴리스 노트가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->