### PR TITLE
[#65] 메인 README에 CollectionViewAdapter 사용 예제 추가

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,29 +180,31 @@ dependencies: [
 
 > **문제**
 >
-> UIKit으로 여러 Collection View 화면을 만들면서
-> Cell과 Header/Footer 등록, Data Source 타입 분기, Section별 Layout 구성,
-> Diffable Snapshot 갱신과 이벤트 연결이 화면마다 반복됐습니다.
-> 화면이 복잡해질수록 ViewController가 구체적인 Cell 타입과 상태 갱신까지 맡아
-> Section을 추가하거나 다른 화면에서 재사용할 때 수정 범위가 커졌습니다.
+> UIKit으로 Collection View 화면을 만들 때마다 Cell과 Header/Footer 등록,
+> Data Source 타입 분기, Section별 Layout 구성이 반복됐습니다.
+> Diffable Snapshot 갱신과 이벤트 연결까지 ViewController가 맡으면서
+> 화면이 복잡해질수록 구체적인 Cell 타입과 상태 갱신 로직이 ViewController에 모였습니다.
+> Section을 추가하거나 같은 UI를 다른 화면에서 재사용할 때 수정 범위도 커졌습니다.
 >
 > **해결**
 >
-> 반복되는 책임을 `CollectionViewAdapter` 공용 모듈로 분리했습니다.
-> `Component`는 `Identifiable & Equatable` Item과 `UIView`의 생성·렌더링 규칙을 연결하고,
-> `SectionModels`는 Header/Footer와 세로 목록, Grid, 가로 Carousel을 선언합니다.
-> Adapter는 generic container 등록, Compositional Layout, stable identity 기반 Snapshot,
-> 재사용 생명주기와 Prefetch/Pagination을 일관된 흐름으로 처리합니다.
-> `Touchable`, `Pressable`, `LongPressable`, `ContainsButton`, `ContainsSwitch`처럼
-> Content가 채택한 capability에 필요한 상호작용만 modifier로 합성하며,
-> Component가 SwiftUI `View`를 함께 채택하면 같은 UI를 SwiftUI에서도 바로 재사용할 수 있습니다.
+> 반복되는 Collection View 구성 책임을 `CollectionViewAdapter` 공용 모듈로 옮겼습니다.
+>
+> - `Component`는 `Identifiable & Equatable` Item과 `UIView`의 생성·렌더링 규칙을 연결합니다.
+> - `SectionModels`는 Header/Footer와 세로 목록, Grid, 가로 Carousel을 선언합니다.
+> - `CollectionViewAdapter`는 generic container 등록, Compositional Layout,
+>   stable identity 기반 Snapshot, 재사용 생명주기, Prefetch/Pagination을 관리합니다.
+>
+> Content는 `Touchable`, `Pressable`, `LongPressable`, `ContainsButton`,
+> `ContainsSwitch` 중 필요한 capability만 채택하고, 각 상호작용은 modifier로 연결합니다.
+> Component가 SwiftUI `View`도 채택하면 같은 UI를 SwiftUI에서 바로 재사용할 수 있습니다.
 >
 > **성과**
 >
-> 🔸 화면마다 반복되던 Cell 등록과 Data Source 타입 분기 제거<br>
-> 🔸 세로 목록, Grid, 가로 Carousel을 같은 Section DSL로 일관되게 구성<br>
-> 🔸 Snapshot 갱신, 재사용, 이벤트, Prefetch와 Pagination 연결을 Adapter에서 통합 관리<br>
-> 🔸 UIKit과 SwiftUI에서 함께 재사용할 수 있는 Component 기반 UI 구조 확보
+> 🔸 ViewController에서 반복되던 Cell 등록과 Data Source 타입 분기 제거<br>
+> 🔸 세로 목록, Grid, 가로 Carousel을 같은 Section DSL로 선언<br>
+> 🔸 Snapshot 갱신, 재사용, 이벤트, Prefetch, Pagination을 Adapter에서 관리<br>
+> 🔸 같은 Component를 UIKit과 SwiftUI에서 재사용
 
 #### CollectionViewAdapter 사용 예제
 

--- a/readme.md
+++ b/readme.md
@@ -204,21 +204,29 @@ dependencies: [
 > 🔸 Snapshot 갱신, 재사용, 이벤트, Prefetch와 Pagination 연결을 Adapter에서 통합 관리<br>
 > 🔸 UIKit과 SwiftUI에서 함께 재사용할 수 있는 Component 기반 UI 구조 확보
 
-```swift
-let sections = SectionModels {
-    LazySection(identifier: "featured") {
-        For(of: featured) { item in
-            PhotoCardComponent(item: item)
-        }
-    }
-    .withSectionLayout(
-        .horizontalCarousel(
-            itemWidth: 0.72,
-            estimatedHeight: 178,
-            spacing: 12
-        )
-    )
+#### CollectionViewAdapter 사용 예제
 
+Demo 앱의 `ReadmeCapture` Section은 주요 사용 방식을 비교하는 네 가지
+예제로 구성됩니다. 앞의 세 화면은 `LazySection`과
+`CollectionViewAdapter`로 서로 다른 Section layout을 구성하고, 마지막
+화면은 `View`를 채택한 Component를 SwiftUI에서 직접 사용합니다.
+
+##### Vertical
+
+가장 단순한 단일 Section 세로 목록입니다. 각 모델을
+`AccountRowComponent`로 변환하고 `.verticalList`로 위에서 아래로
+배치합니다.
+
+<table>
+<tr><th>Source</th><th>Result</th></tr>
+<tr>
+<td width="65%">
+
+```swift
+import CollectionViewAdapter
+import UIKit
+
+let sections = SectionModels {
     LazySection(identifier: "accounts") {
         For(of: accounts) { account in
             AccountRowComponent(item: account)
@@ -231,5 +239,189 @@ let sections = SectionModels {
 
 adapter.bind(sections)
 ```
+
+</td>
+<td width="35%" align="center">
+
+<img width="280" alt="CollectionViewAdapter vertical example" src="Projects/Shared/CollectionViewAdapter/docs/images/readme/vertical.png">
+
+</td>
+</tr>
+</table>
+
+##### Grid
+
+카드 Component를 별도의 Cell subclass 없이 2열 Grid로 배치합니다.
+열 수, Item 간격, 행 간격과 바깥 여백은 Section layout이 담당합니다.
+
+<table>
+<tr><th>Source</th><th>Result</th></tr>
+<tr>
+<td width="65%">
+
+```swift
+let sections = SectionModels {
+    LazySection(identifier: "cards") {
+        For(of: cards) { item in
+            PhotoCardComponent(item: item)
+        }
+    }
+    .withSectionLayout(
+        .grid(
+            columns: 2,
+            estimatedRowHeight: 178,
+            interItemSpacing: 12,
+            lineSpacing: 12,
+            contentInsets: .init(
+                top: 20,
+                leading: 20,
+                bottom: 24,
+                trailing: 20
+            )
+        )
+    )
+}
+
+adapter.bind(sections)
+```
+
+</td>
+<td width="35%" align="center">
+
+<img width="280" alt="CollectionViewAdapter grid example" src="Projects/Shared/CollectionViewAdapter/docs/images/readme/grid.png">
+
+</td>
+</tr>
+</table>
+
+##### Horizontal + Vertical
+
+한 Collection View 안에서 Section마다 서로 다른 스크롤 방향을 선언할 수
+있습니다. 첫 번째 Section은 가로 Carousel로 움직이고, 두 번째 Section은
+일반 세로 목록으로 이어집니다.
+
+<table>
+<tr><th>Source</th><th>Result</th></tr>
+<tr>
+<td width="65%">
+
+```swift
+let sections = SectionModels {
+    LazySection(identifier: "featured") {
+        For(of: featured) { item in
+            PhotoCardComponent(item: item)
+        }
+    }
+    .withHeader(
+        TitleComponent(title: "Horizontal")
+    )
+    .withSectionLayout(
+        .horizontalCarousel(
+            itemWidth: 0.72,
+            estimatedHeight: 178,
+            spacing: 12,
+            behavior: .continuousGroupLeadingBoundary,
+            contentInsets: .init(
+                top: 8,
+                leading: 20,
+                bottom: 24,
+                trailing: 20
+            )
+        )
+    )
+
+    LazySection(identifier: "accounts") {
+        For(of: accounts) { account in
+            AccountRowComponent(item: account)
+        }
+    }
+    .withHeader(
+        TitleComponent(title: "Vertical")
+    )
+    .withSectionLayout(
+        .verticalList(
+            spacing: 10,
+            contentInsets: .init(
+                top: 8,
+                leading: 20,
+                bottom: 24,
+                trailing: 20
+            )
+        )
+    )
+}
+
+adapter.bind(sections)
+```
+
+</td>
+<td width="35%" align="center">
+
+<img width="280" alt="CollectionViewAdapter horizontal and vertical sections example" src="Projects/Shared/CollectionViewAdapter/docs/images/readme/mixed-sections.png">
+
+</td>
+</tr>
+</table>
+
+Section마다 독립적인 `CollectionSectionLayout`을 가지므로 가로 Section의
+orthogonal scrolling과 화면 전체의 세로 스크롤을 한 Adapter에서 함께
+처리할 수 있습니다.
+
+##### Component를 SwiftUI에서 바로 사용하기
+
+`Component`가 SwiftUI `View`도 함께 채택하면 Component 자체를 SwiftUI
+View hierarchy에 바로 배치할 수 있습니다. 모듈이 기본 `body`를 제공하므로
+별도의 `ComponentView` wrapper를 호출할 필요가 없습니다.
+
+<table>
+<tr><th>Source</th><th>Result</th></tr>
+<tr>
+<td width="65%">
+
+```swift
+import CollectionViewAdapter
+import SwiftUI
+
+struct AccountRowComponent: Component, View {
+    let item: Account
+
+    func createContent() -> AccountContentView {
+        AccountContentView()
+    }
+
+    func render(
+        context: ComponentContext,
+        content: AccountContentView
+    ) {
+        content.configure(with: item)
+    }
+}
+
+struct AccountStack: View {
+    let accounts: [Account]
+
+    var body: some View {
+        VStack(spacing: 10) {
+            ForEach(accounts) { account in
+                AccountRowComponent(item: account)
+                    .frame(height: 84)
+            }
+        }
+    }
+}
+```
+
+</td>
+<td width="35%" align="center">
+
+<img width="280" alt="Component used directly as a SwiftUI View" src="Projects/Shared/CollectionViewAdapter/docs/images/readme/swiftui-component.png">
+
+</td>
+</tr>
+</table>
+
+Collection View에서 사용할 때는 같은 Component를 `LazySection`에 넣고,
+SwiftUI에서는 `VStack`, `ForEach` 같은 View 구성 안에 직접 넣습니다.
+두 환경 모두 같은 `createContent`와 `render` 계약을 사용합니다.
 
 [CollectionViewAdapter의 구조와 예제 자세히 보기](Projects/Shared/CollectionViewAdapter/README.md)


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [x] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- 루트 `Readme.md`의 핵심 성과 4번 아래에 CollectionViewAdapter 사용 예제 영역을 추가했습니다.
- 기존 가로·세로 혼합 코드 한 개를 Vertical, Grid, Horizontal + Vertical, SwiftUI Component의 네 가지 Source/Result 예제로 확장했습니다.
- 모듈 README의 설명과 코드를 그대로 반영하고, 문서 계층에 맞춰 예제 제목을 하위 heading으로 구성했습니다.
- 캡처 이미지 경로를 루트 README 기준으로 변경하고 상세 CollectionViewAdapter README 링크를 예제 뒤에 유지했습니다.

## 🚨 관련 이슈

- close #65

## 🎨 스크린샷

| 기능 | 스크린샷 |
| :--: | :------: |
| CollectionViewAdapter 사용 예제 | README 내부에 기존 캡처 이미지 4개 표시 |

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- 모듈 README와 네 가지 예제의 설명·코드가 일치하는지 비교했습니다.
- 루트 기준 이미지 경로 4개가 실제 파일을 가리키는지 확인했습니다.
- Markdown 코드 펜스와 HTML table 태그의 짝을 검증했습니다.
- `git diff --check`를 통과했습니다.
- 문서만 변경해 앱 빌드와 테스트는 실행하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * CollectionViewAdapter의 “Horizontal + Vertical” 사용 예제를 업데이트했습니다.
  * 수직 헤더와 `verticalList` 레이아웃 중심으로 예제를 정리해 사용 흐름을 더 명확하게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->