### PR TITLE
[#67] UI 테스트 실행 전 게시글 데이터를 초기화한다

### DIFF
--- a/Projects/App/Sources/SceneDelegate/SceneDelegate+UITests.swift
+++ b/Projects/App/Sources/SceneDelegate/SceneDelegate+UITests.swift
@@ -8,14 +8,29 @@
 import UIKit
 import Core
 import Domain
+import RxSwift
 
 #if DEBUG
 extension SceneDelegate {
-    func configureForUITests() {
+    @discardableResult
+    func configureForUITests(
+        completion: @escaping () -> Void
+    ) -> Bool {
+        guard
+            ProcessInfo.processInfo.arguments.contains("-UITest")
+        else {
+            return false
+        }
+
         let environment = ProcessInfo.processInfo.environment
-        guard let uid = environment["TEST_USER_UID"] else { return }
+        guard let uid = environment["TEST_USER_UID"] else {
+            Logger.e("UI 테스트 사용자 UID가 설정되지 않음")
+            assertionFailure("TEST_USER_UID가 필요합니다.")
+            return true
+        }
         
         let authUsecase = DIContainer.shared.resolve(AuthUsecaseProtocol.self)
+        let groupUsecase = DIContainer.shared.resolve(GroupUsecaseProtocol.self)
         let userSession = DIContainer.shared.resolve(UserSession.self)
         let groupSession = DIContainer.shared.resolve(GroupSession.self)
         
@@ -24,15 +39,36 @@ extension SceneDelegate {
         groupSession.clear()
         Logger.d("테스트 시작: 기존 세션 초기화")
         
-        // 2. 테스트 유저 주입
-        authUsecase.bootstrapUserSession(uid: uid)
-            .subscribe(onSuccess: { user in
-                Logger.d("테스트 유저 부트스트랩 성공: \(user.uid)")
-            }, onFailure: { error in
-                Logger.d("⚠️ 테스트 유저 부트스트랩 실패: \(error)")
-                assertionFailure("UI 테스트 사용자 설정 실패 - UID: \(uid)")
-            })
+        // 2. 테스트 유저 주입 후 기존 게시글 정리
+        authUsecase
+            .bootstrapUserSession(uid: uid)
+            .flatMap { user in
+                groupUsecase
+                    .resetPostsForUITests()
+                    .map { removedPostCount in
+                        (
+                            user: user,
+                            removedPostCount: removedPostCount
+                        )
+                    }
+            }
+            .subscribe(
+                onSuccess: { result in
+                    Logger.d(
+                        "UI 테스트 준비 완료: \(result.user.uid), 게시글 \(result.removedPostCount)개 정리"
+                    )
+                    DispatchQueue.main.async(execute: completion)
+                },
+                onFailure: { error in
+                    Logger.e("UI 테스트 초기 데이터 정리 실패: \(error)")
+                    assertionFailure(
+                        "UI 테스트 초기 데이터 정리에 실패했습니다: \(error)"
+                    )
+                }
+            )
             .disposed(by: disposeBag)
+
+        return true
     }
 }
 #endif

--- a/Projects/App/Sources/SceneDelegate/SceneDelegate.swift
+++ b/Projects/App/Sources/SceneDelegate/SceneDelegate.swift
@@ -45,7 +45,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.appCoordinator = appCoordinator
         
         #if DEBUG
-        self.configureForUITests()
+        if configureForUITests(
+            completion: {
+                appCoordinator.start()
+            }
+        ) {
+            return
+        }
         #endif
         appCoordinator.start()
 

--- a/Projects/Domain/Sources/Usecase/GroupUsecase.swift
+++ b/Projects/Domain/Sources/Usecase/GroupUsecase.swift
@@ -36,6 +36,10 @@ public protocol GroupUsecaseProtocol {
     func deleteComment(post: Post, commentId: String) -> Single<Void>
     func uploadImageAndUploadPost(image: UIImage) -> Observable<Void>
     func deletePostAndReload(post: Post) -> Observable<Void>
+
+    #if DEBUG
+    func resetPostsForUITests() -> Single<Int>
+    #endif
 }
 
 public extension GroupUsecaseProtocol {
@@ -49,6 +53,15 @@ public extension GroupUsecaseProtocol {
         )
     }
 }
+
+#if DEBUG
+public extension GroupUsecaseProtocol {
+    /// 실제 저장소를 사용하지 않는 Demo 구현을 위한 기본 동작입니다.
+    func resetPostsForUITests() -> Single<Int> {
+        .just(0)
+    }
+}
+#endif
 
 public final class GroupUsecaseImpl: GroupUsecaseProtocol {
     private let groupRepository: GroupRepositoryProtocol
@@ -261,4 +274,50 @@ public final class GroupUsecaseImpl: GroupUsecaseProtocol {
             }
             .mapToVoid()
     }
+
+    #if DEBUG
+    public func resetPostsForUITests() -> Single<Int> {
+        guard let groupId = userSession.groupId else {
+            return .error(DomainError.missingGroupId)
+        }
+
+        let repository = groupRepository
+
+        return repository
+            .fetchGroup(groupId: groupId)
+            .flatMap { [weak self] group -> Single<Int> in
+                let posts = group.postsByDate.values.flatMap { $0 }
+                let postsPath = "groups/\(groupId)/postsByDate"
+
+                let deleteImages = Observable
+                    .from(posts)
+                    .flatMap { post in
+                        repository
+                            .deleteImage(
+                                path: "groups/\(groupId)/images/\(post.postId).jpg"
+                            )
+                            .asObservable()
+                            .catch { error in
+                                Logger.w(
+                                    "UI 테스트 이미지 정리 실패: \(post.postId), \(error)"
+                                )
+                                return .just(())
+                            }
+                    }
+                    .toArray()
+                    .map { _ in () }
+
+                return repository
+                    .deleteValue(path: postsPath)
+                    .flatMap { deleteImages }
+                    .do(onSuccess: {
+                        self?.groupSession.update(
+                            \.postsByDate,
+                            [:]
+                        )
+                    })
+                    .map { posts.count }
+            }
+    }
+    #endif
 }


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- `-UITest` 실행 시 고정 테스트 사용자 세션을 구성한 뒤 해당 그룹의 기존 게시글을 초기화하도록 변경했습니다.
- Firebase Realtime Database의 `postsByDate`와 게시글에 연결된 Storage 이미지를 함께 정리합니다.
- 초기화가 완료된 후 `AppCoordinator`를 시작해 원격 데이터 정리와 첫 화면 로딩 사이의 경쟁 상태를 방지합니다.
- 초기화 로직은 `DEBUG` 빌드이면서 `-UITest` 인자가 전달된 경우에만 실행됩니다.
- 데이터베이스 초기화에 실패하면 테스트를 즉시 실패시키고, 개별 이미지 정리 실패는 로그를 남긴 뒤 계속 진행합니다.

## 🚨 관련 이슈

- close #67

## 🎨 스크린샷

UI 변경 없음

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- `tuist generate --no-open` 성공
- App Debug 구성의 `xcodebuild build-for-testing` 성공
- 실제 UI 테스트 실행은 Firebase 테스트 그룹의 기존 게시글을 삭제하므로 수동으로 실행하지 않았습니다. PR CI에서 테스트 초기화 동작을 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * UI 테스트 실행 시 테스트용 사용자 세션을 자동으로 준비합니다.
  * 기존 게시물을 초기화해 테스트 환경을 일관되게 유지합니다.
  * 테스트 준비가 완료된 후 앱이 정상적으로 시작되도록 개선했습니다.
  * 게시물 및 이미지 정리 결과를 처리하고, 초기화 실패 상황을 감지할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->