### PR TITLE
[#69] 첫 릴리스 노트 생성 fallback을 추가한다

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  categories:
+    - title: '✨ 새로운 기능이 추가되었어요'
+      labels:
+        - '✨ feature'
+    - title: '🐞 자잘한 버그를 수정했어요'
+      labels:
+        - '🔧 fix'
+        - '🔥 hotfix'
+    - title: '🛠 코드를 개선했어요'
+      labels:
+        - '⚙️ chore'
+        - '🔨 refactor'
+        - '✅ test'
+        - '📃 docs'
+    - title: '기타 변경'
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,59 @@ jobs:
             exit 1
           fi
 
+      - name: Inspect release history
+        id: release-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          current_release_count="$(
+            gh api \
+              --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq ".[] | select(.tag_name == \"${TAG}\") | .id" \
+              | wc -l \
+              | tr -d '[:space:]'
+          )"
+
+          if (( current_release_count > 1 )); then
+            echo "::error::Multiple releases use tag ${TAG}. Resolve the duplicates before retrying."
+            exit 1
+          fi
+
+          current_state="$(
+            gh api \
+              --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq ".[] | select(.tag_name == \"${TAG}\") | if .draft then \"draft\" else \"published\" end"
+          )"
+
+          if [[ "$current_state" == "published" ]]; then
+            echo "::error::Release ${TAG} is already published."
+            exit 1
+          fi
+
+          published_release_count="$(
+            gh api \
+              --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq '.[] | select(.draft == false and .prerelease == false) | .id' \
+              | wc -l \
+              | tr -d '[:space:]'
+          )"
+
+          if (( published_release_count > 0 )); then
+            echo "has_previous=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_previous=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "current_state=${current_state:-none}" >> "$GITHUB_OUTPUT"
+
       - name: Create ${{ inputs.release_mode }} release with generated notes
+        if: steps.release-state.outputs.has_previous == 'true'
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
@@ -60,3 +112,52 @@ jobs:
           commitish: ${{ inputs.target_branch }}
           publish: ${{ inputs.release_mode == 'latest' }}
           latest: ${{ inputs.release_mode == 'latest' }}
+
+      - name: Create first ${{ inputs.release_mode }} release with generated notes
+        if: steps.release-state.outputs.has_previous == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: v${{ inputs.version }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RELEASE_MODE: ${{ inputs.release_mode }}
+          CURRENT_STATE: ${{ steps.release-state.outputs.current_state }}
+        run: |
+          set -euo pipefail
+
+          notes_file="${RUNNER_TEMP}/release-notes.md"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            -f target_commitish="$TARGET_BRANCH" \
+            --jq '.body' \
+            > "$notes_file"
+
+          if [[ "$CURRENT_STATE" == "draft" ]]; then
+            release_command=(
+              release edit "$TAG"
+              --repo "$GITHUB_REPOSITORY"
+              --target "$TARGET_BRANCH"
+              --title "$TAG"
+              --notes-file "$notes_file"
+            )
+          else
+            release_command=(
+              release create "$TAG"
+              --repo "$GITHUB_REPOSITORY"
+              --target "$TARGET_BRANCH"
+              --title "$TAG"
+              --notes-file "$notes_file"
+            )
+          fi
+
+          if [[ "$RELEASE_MODE" == "latest" ]]; then
+            if [[ "$CURRENT_STATE" == "draft" ]]; then
+              release_command+=(--draft=false)
+            fi
+            release_command+=(--latest)
+          else
+            release_command+=(--draft)
+          fi
+
+          gh "${release_command[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,11 +79,6 @@ jobs:
               --jq ".[] | select(.tag_name == \"${TAG}\") | if .draft then \"draft\" else \"published\" end"
           )"
 
-          if [[ "$current_state" == "published" ]]; then
-            echo "::error::Release ${TAG} is already published."
-            exit 1
-          fi
-
           published_release_count="$(
             gh api \
               --paginate \
@@ -102,7 +97,9 @@ jobs:
           echo "current_state=${current_state:-none}" >> "$GITHUB_OUTPUT"
 
       - name: Create ${{ inputs.release_mode }} release with generated notes
-        if: steps.release-state.outputs.has_previous == 'true'
+        if: >-
+          steps.release-state.outputs.has_previous == 'true' &&
+          steps.release-state.outputs.current_state != 'published'
         uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
@@ -113,8 +110,10 @@ jobs:
           publish: ${{ inputs.release_mode == 'latest' }}
           latest: ${{ inputs.release_mode == 'latest' }}
 
-      - name: Create first ${{ inputs.release_mode }} release with generated notes
-        if: steps.release-state.outputs.has_previous == 'false'
+      - name: Create or overwrite ${{ inputs.release_mode }} release with generated notes
+        if: >-
+          steps.release-state.outputs.has_previous == 'false' ||
+          steps.release-state.outputs.current_state == 'published'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: v${{ inputs.version }}
@@ -133,7 +132,7 @@ jobs:
             --jq '.body' \
             > "$notes_file"
 
-          if [[ "$CURRENT_STATE" == "draft" ]]; then
+          if [[ "$CURRENT_STATE" == "draft" || "$CURRENT_STATE" == "published" ]]; then
             release_command=(
               release edit "$TAG"
               --repo "$GITHUB_REPOSITORY"
@@ -152,7 +151,7 @@ jobs:
           fi
 
           if [[ "$RELEASE_MODE" == "latest" ]]; then
-            if [[ "$CURRENT_STATE" == "draft" ]]; then
+            if [[ "$CURRENT_STATE" == "draft" || "$CURRENT_STATE" == "published" ]]; then
               release_command+=(--draft=false)
             fi
             release_command+=(--latest)


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [x] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

### 문제

- Release Drafter v7은 이전에 게시된 GitHub Release를 기준으로 병합 PR 범위를 계산합니다.
- `v1.1.0`은 저장소의 첫 릴리스여서 비교 기준이 없었고, 변경사항이 빈 상태로 경고 문구와 함께 게시됐습니다.

### 해결

- 워크플로 실행 시 게시된 정식 릴리스와 동일 태그의 기존 릴리스 상태를 먼저 확인합니다.
- 첫 릴리스는 GitHub Release Notes API를 사용해 저장소 시작부터 병합된 PR을 릴리스 노트로 생성합니다.
- 두 번째 이후 릴리스는 기존 Release Drafter와 한국어 템플릿을 그대로 사용합니다.
- 첫 릴리스 draft의 반복 갱신과 `latest` 게시 전환을 모두 지원합니다.
- 동일 태그의 게시 릴리스가 하나면 생성 노트를 다시 만들고 기존 Release를 제자리에서 강제 갱신합니다.
- 기존 Release의 URL과 첨부 자산은 보존하며, 동일 태그 Release가 여러 개일 때만 안전하게 실패합니다.
- `.github/release.yml`에 저장소 라벨과 동일한 변경사항 분류를 추가했습니다.

## 🚨 관련 이슈

- close #69

## 🎨 스크린샷

UI 변경 없음

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- Ruby YAML 파싱으로 `.github/workflows/release.yml`, `.github/release.yml` 검증
- `bash -n`으로 워크플로의 모든 `run` 블록 구문 검증
- GitHub `generate-notes` API가 첫 릴리스 기준으로 3,859자의 변경사항을 생성하는 것을 확인
- 원격 브랜치의 `.github/release.yml`을 지정한 생성 노트 API 호출 성공
- 실제 Release Action은 새 릴리스를 생성하므로 재실행하지 않음
- 기존에 게시된 `v1.1.0` 본문은 이 PR에서 변경하지 않음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 릴리스 노트를 기능, 버그 수정, 개선, 문서 등으로 자동 분류합니다.
  * 최초 릴리스에서도 변경 사항을 기반으로 릴리스 노트를 자동 생성합니다.

* **개선 사항**
  * 기존 릴리스가 있는 경우 해당 릴리스를 자동으로 업데이트합니다.
  * 릴리스 상태에 따라 초안 또는 최신 릴리스로 생성할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->