### PR TITLE
[#73] 단건 및 전체 FCM 테스트 알림 스크립트 추가

### DIFF
--- a/firebase/functions-typescript/package.json
+++ b/firebase/functions-typescript/package.json
@@ -8,6 +8,7 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "notification:test": "npm run build && node lib/scripts/send-test-notification.js",
+    "notification:announcement": "npm run build && node lib/scripts/send-announcement-notification.js",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },

--- a/firebase/functions-typescript/package.json
+++ b/firebase/functions-typescript/package.json
@@ -7,6 +7,7 @@
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
+    "notification:test": "npm run build && node lib/scripts/send-test-notification.js",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },

--- a/firebase/functions-typescript/src/scripts/notification-utils.ts
+++ b/firebase/functions-typescript/src/scripts/notification-utils.ts
@@ -1,0 +1,119 @@
+import * as admin from "firebase-admin";
+
+import "../config";
+
+export interface NotificationUserData {
+  nickname?: unknown;
+  isPushEnabled?: unknown;
+  fcmToken?: unknown;
+}
+
+const invalidTokens = new Set(["", "noFCM", "noToken"]);
+
+/**
+ * 필수 환경 변수를 읽습니다.
+ * @param name 환경 변수 이름
+ * @returns 환경 변수 값
+ */
+function getRequiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+/**
+ * Cloud Functions와 같은 환경 변수로 Firebase Admin SDK를 초기화합니다.
+ * @returns 초기화된 Firebase 앱
+ */
+export function initializeFirebaseAdmin(): admin.app.App {
+  if (admin.apps.length > 0) {
+    return admin.app();
+  }
+
+  const projectId = getRequiredEnv("APP_PROJECT_ID");
+  const databaseURL = getRequiredEnv("APP_DATABASE_URL");
+  const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL?.trim();
+  const privateKeyValue =
+    process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY;
+  const privateKey = privateKeyValue?.replace(/\\n/g, "\n");
+
+  if ((clientEmail && !privateKey) || (!clientEmail && privateKey)) {
+    throw new Error(
+        "Both GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL and " +
+        "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY must be provided together.",
+    );
+  }
+
+  const credential =
+    clientEmail && privateKey ?
+      admin.credential.cert({
+        projectId:
+          process.env.GOOGLE_SERVICE_ACCOUNT_PROJECT_ID?.trim() || projectId,
+        clientEmail,
+        privateKey,
+      }) :
+      admin.credential.applicationDefault();
+
+  return admin.initializeApp({
+    credential,
+    databaseURL,
+    projectId,
+  });
+}
+
+/**
+ * 사용자 데이터에서 화면에 표시할 닉네임을 읽습니다.
+ * @param user 사용자 데이터
+ * @returns 닉네임
+ */
+export function getNickname(user: NotificationUserData): string {
+  return typeof user.nickname === "string" && user.nickname.trim() ?
+    user.nickname.trim() :
+    "알 수 없는 사용자";
+}
+
+/**
+ * 사용자 데이터의 FCM 토큰이 유효한 문자열인지 확인합니다.
+ * @param value FCM 토큰 후보
+ * @returns 유효한 토큰 또는 null
+ */
+export function getValidFcmToken(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const token = value.trim();
+  return invalidTokens.has(token) ? null : token;
+}
+
+/**
+ * 로그에 FCM 토큰 전체가 노출되지 않도록 일부만 남깁니다.
+ * @param token FCM 토큰
+ * @returns 마스킹된 토큰
+ */
+export function maskToken(token: string): string {
+  if (token.length <= 14) {
+    return "***";
+  }
+  return `${token.slice(0, 8)}...${token.slice(-6)}`;
+}
+
+/**
+ * iOS 배너와 기본 알림음에 필요한 APNs 설정을 생성합니다.
+ * @returns APNs alert 설정
+ */
+export function createApnsAlertConfig(): admin.messaging.ApnsConfig {
+  return {
+    headers: {
+      "apns-priority": "10",
+      "apns-push-type": "alert",
+    },
+    payload: {
+      aps: {
+        sound: "default",
+      },
+    },
+  };
+}

--- a/firebase/functions-typescript/src/scripts/send-announcement-notification.ts
+++ b/firebase/functions-typescript/src/scripts/send-announcement-notification.ts
@@ -1,0 +1,229 @@
+import * as admin from "firebase-admin";
+
+import {
+  createApnsAlertConfig,
+  getNickname,
+  getValidFcmToken,
+  initializeFirebaseAdmin,
+  maskToken,
+  NotificationUserData,
+} from "./notification-utils";
+
+interface Recipient {
+  userId: string;
+  nickname: string;
+  token: string;
+}
+
+interface RecipientResult {
+  recipients: Recipient[];
+  disabledCount: number;
+  invalidTokenCount: number;
+  duplicateTokenCount: number;
+}
+
+const multicastBatchSize = 500;
+
+/**
+ * 명령행 옵션 뒤의 문자열 값을 읽습니다.
+ * @param optionName 옵션 이름
+ * @returns 옵션 값 또는 undefined
+ */
+function getOptionValue(optionName: string): string | undefined {
+  const optionIndex = process.argv.indexOf(optionName);
+  if (optionIndex < 0) {
+    return undefined;
+  }
+
+  const value = process.argv[optionIndex + 1]?.trim();
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${optionName} 뒤에 값을 입력해야 합니다.`);
+  }
+  return value;
+}
+
+/**
+ * 명령행 옵션 또는 환경 변수에서 공지 내용을 읽습니다.
+ * @param optionName 명령행 옵션 이름
+ * @param envName 환경 변수 이름
+ * @returns 공지 문자열
+ */
+function getRequiredAnnouncementText(
+    optionName: string,
+    envName: string,
+): string {
+  const value =
+    getOptionValue(optionName) ||
+    process.env[envName]?.trim();
+
+  if (!value) {
+    throw new Error(
+        `${optionName} 또는 ${envName} 환경 변수로 공지 내용을 입력해야 합니다.`,
+    );
+  }
+  return value.replace(/\\n/g, "\n");
+}
+
+/**
+ * Realtime Database 사용자 중 공지 알림 수신 대상을 반환합니다.
+ * @returns 수신 대상 및 제외 사유별 개수
+ */
+async function getRecipients(): Promise<RecipientResult> {
+  const snapshot = await admin.database()
+      .ref("/users")
+      .once("value");
+  const users = snapshot.val() as
+    Record<string, NotificationUserData> | null;
+
+  if (!users || typeof users !== "object") {
+    throw new Error("Realtime Database에 사용자 데이터가 없습니다.");
+  }
+
+  const recipientsByToken = new Map<string, Recipient>();
+  let disabledCount = 0;
+  let invalidTokenCount = 0;
+  let duplicateTokenCount = 0;
+
+  for (const [userId, user] of Object.entries(users)) {
+    if (!user || typeof user !== "object") {
+      invalidTokenCount += 1;
+      continue;
+    }
+
+    if (user.isPushEnabled !== true) {
+      disabledCount += 1;
+      continue;
+    }
+
+    const token = getValidFcmToken(user.fcmToken);
+    if (!token) {
+      invalidTokenCount += 1;
+      continue;
+    }
+
+    if (recipientsByToken.has(token)) {
+      duplicateTokenCount += 1;
+      continue;
+    }
+
+    recipientsByToken.set(token, {
+      userId,
+      nickname: getNickname(user),
+      token,
+    });
+  }
+
+  return {
+    recipients: Array.from(recipientsByToken.values()),
+    disabledCount,
+    invalidTokenCount,
+    duplicateTokenCount,
+  };
+}
+
+/**
+ * 전체 수신 대상을 500개 단위로 나누어 공지 알림을 전송합니다.
+ */
+async function main(): Promise<void> {
+  const dryRun = process.argv.includes("--dry-run");
+  const confirmed = process.argv.includes("--confirm");
+  const title = getRequiredAnnouncementText(
+      "--title",
+      "ANNOUNCEMENT_TITLE",
+  );
+  const body = getRequiredAnnouncementText(
+      "--body",
+      "ANNOUNCEMENT_BODY",
+  );
+
+  if (!dryRun && !confirmed) {
+    throw new Error(
+        "전체 공지 실제 전송에는 --confirm 옵션이 필요합니다. " +
+        "먼저 --dry-run으로 검증하세요.",
+    );
+  }
+
+  const app = initializeFirebaseAdmin();
+
+  try {
+    const {
+      recipients,
+      disabledCount,
+      invalidTokenCount,
+      duplicateTokenCount,
+    } = await getRecipients();
+
+    if (recipients.length === 0) {
+      throw new Error("공지 알림을 받을 수 있는 사용자가 없습니다.");
+    }
+
+    console.log(`➡️ 공지 제목: ${title}`);
+    console.log(`➡️ 공지 본문: ${body}`);
+    console.log(`➡️ 전송 모드: ${dryRun ? "검증만 수행" : "실제 전송"}`);
+    console.log(`➡️ 전송 대상: ${recipients.length}명`);
+    console.log(`➡️ 알림 비활성화 제외: ${disabledCount}명`);
+    console.log(`➡️ 유효하지 않은 토큰 제외: ${invalidTokenCount}명`);
+    console.log(`➡️ 중복 토큰 제외: ${duplicateTokenCount}명`);
+
+    let totalSuccess = 0;
+    let totalFailure = 0;
+
+    for (
+      let startIndex = 0;
+      startIndex < recipients.length;
+      startIndex += multicastBatchSize
+    ) {
+      const batch = recipients.slice(
+          startIndex,
+          startIndex + multicastBatchSize,
+      );
+      const response = await admin.messaging().sendEachForMulticast(
+          {
+            tokens: batch.map((recipient) => recipient.token),
+            notification: {
+              title,
+              body,
+            },
+            data: {
+              type: "announcement",
+            },
+            apns: createApnsAlertConfig(),
+          },
+          dryRun,
+      );
+
+      totalSuccess += response.successCount;
+      totalFailure += response.failureCount;
+
+      response.responses.forEach((result, index) => {
+        if (result.success) {
+          return;
+        }
+
+        const recipient = batch[index];
+        const errorCode = result.error?.code || "unknown";
+        console.error(
+            `❌ ${recipient.nickname} ` +
+            `(${maskToken(recipient.token)}) 전송 실패: ${errorCode}`,
+        );
+      });
+    }
+
+    console.log(
+        `${dryRun ? "✅ 전체 공지 검증 완료" : "✅ 전체 공지 전송 완료"}: ` +
+        `성공 ${totalSuccess}건, 실패 ${totalFailure}건`,
+    );
+
+    if (totalFailure > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await app.delete();
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ 전체 공지 처리 실패: ${message}`);
+  process.exitCode = 1;
+});

--- a/firebase/functions-typescript/src/scripts/send-test-notification.ts
+++ b/firebase/functions-typescript/src/scripts/send-test-notification.ts
@@ -1,75 +1,13 @@
 import * as admin from "firebase-admin";
 
-import "../config";
-
-interface UserData {
-  nickname?: unknown;
-  isPushEnabled?: unknown;
-  fcmToken?: unknown;
-}
-
-const invalidTokens = new Set(["", "noFCM", "noToken"]);
-
-/**
- * 필수 환경 변수를 읽습니다.
- * @param name 환경 변수 이름
- * @returns 환경 변수 값
- */
-function getRequiredEnv(name: string): string {
-  const value = process.env[name]?.trim();
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
-
-/**
- * Cloud Functions와 같은 환경 변수로 Firebase Admin SDK를 초기화합니다.
- * @returns 초기화된 Firebase 앱
- */
-function initializeFirebaseAdmin(): admin.app.App {
-  const projectId = getRequiredEnv("APP_PROJECT_ID");
-  const databaseURL = getRequiredEnv("APP_DATABASE_URL");
-  const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL?.trim();
-  const privateKeyValue =
-    process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY;
-  const privateKey = privateKeyValue?.replace(/\\n/g, "\n");
-
-  if ((clientEmail && !privateKey) || (!clientEmail && privateKey)) {
-    throw new Error(
-        "Both GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL and " +
-        "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY must be provided together.",
-    );
-  }
-
-  const credential =
-    clientEmail && privateKey ?
-      admin.credential.cert({
-        projectId:
-          process.env.GOOGLE_SERVICE_ACCOUNT_PROJECT_ID?.trim() || projectId,
-        clientEmail,
-        privateKey,
-      }) :
-      admin.credential.applicationDefault();
-
-  return admin.initializeApp({
-    credential,
-    databaseURL,
-    projectId,
-  });
-}
-
-/**
- * 로그에 FCM 토큰 전체가 노출되지 않도록 일부만 남깁니다.
- * @param token FCM 토큰
- * @returns 마스킹된 토큰
- */
-function maskToken(token: string): string {
-  if (token.length <= 14) {
-    return "***";
-  }
-  return `${token.slice(0, 8)}...${token.slice(-6)}`;
-}
+import {
+  createApnsAlertConfig,
+  getNickname,
+  getValidFcmToken,
+  initializeFirebaseAdmin,
+  maskToken,
+  NotificationUserData,
+} from "./notification-utils";
 
 /**
  * 명령행 인자 또는 환경 변수에서 테스트 대상 사용자 UID를 읽습니다.
@@ -111,27 +49,21 @@ async function main(): Promise<void> {
     const snapshot = await admin.database()
         .ref(`/users/${userId}`)
         .once("value");
-    const user = snapshot.val() as UserData | null;
+    const user = snapshot.val() as NotificationUserData | null;
 
     if (!user || typeof user !== "object") {
       throw new Error(`User not found: ${userId}`);
     }
 
-    const nickname =
-      typeof user.nickname === "string" && user.nickname.trim() ?
-        user.nickname.trim() :
-        "알 수 없는 사용자";
+    const nickname = getNickname(user);
 
     if (user.isPushEnabled !== true) {
       throw new Error(`${nickname} 사용자는 알림 설정이 꺼져 있습니다.`);
     }
 
-    const token =
-      typeof user.fcmToken === "string" ?
-        user.fcmToken.trim() :
-        "";
+    const token = getValidFcmToken(user.fcmToken);
 
-    if (invalidTokens.has(token)) {
+    if (!token) {
       throw new Error(`${nickname} 사용자의 유효한 FCM 토큰이 없습니다.`);
     }
 
@@ -150,17 +82,7 @@ async function main(): Promise<void> {
             type: "test",
             userId,
           },
-          apns: {
-            headers: {
-              "apns-priority": "10",
-              "apns-push-type": "alert",
-            },
-            payload: {
-              aps: {
-                sound: "default",
-              },
-            },
-          },
+          apns: createApnsAlertConfig(),
         },
         dryRun,
     );

--- a/firebase/functions-typescript/src/scripts/send-test-notification.ts
+++ b/firebase/functions-typescript/src/scripts/send-test-notification.ts
@@ -1,0 +1,181 @@
+import * as admin from "firebase-admin";
+
+import "../config";
+
+interface UserData {
+  nickname?: unknown;
+  isPushEnabled?: unknown;
+  fcmToken?: unknown;
+}
+
+const invalidTokens = new Set(["", "noFCM", "noToken"]);
+
+/**
+ * 필수 환경 변수를 읽습니다.
+ * @param name 환경 변수 이름
+ * @returns 환경 변수 값
+ */
+function getRequiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+/**
+ * Cloud Functions와 같은 환경 변수로 Firebase Admin SDK를 초기화합니다.
+ * @returns 초기화된 Firebase 앱
+ */
+function initializeFirebaseAdmin(): admin.app.App {
+  const projectId = getRequiredEnv("APP_PROJECT_ID");
+  const databaseURL = getRequiredEnv("APP_DATABASE_URL");
+  const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL?.trim();
+  const privateKeyValue =
+    process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY;
+  const privateKey = privateKeyValue?.replace(/\\n/g, "\n");
+
+  if ((clientEmail && !privateKey) || (!clientEmail && privateKey)) {
+    throw new Error(
+        "Both GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL and " +
+        "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY must be provided together.",
+    );
+  }
+
+  const credential =
+    clientEmail && privateKey ?
+      admin.credential.cert({
+        projectId:
+          process.env.GOOGLE_SERVICE_ACCOUNT_PROJECT_ID?.trim() || projectId,
+        clientEmail,
+        privateKey,
+      }) :
+      admin.credential.applicationDefault();
+
+  return admin.initializeApp({
+    credential,
+    databaseURL,
+    projectId,
+  });
+}
+
+/**
+ * 로그에 FCM 토큰 전체가 노출되지 않도록 일부만 남깁니다.
+ * @param token FCM 토큰
+ * @returns 마스킹된 토큰
+ */
+function maskToken(token: string): string {
+  if (token.length <= 14) {
+    return "***";
+  }
+  return `${token.slice(0, 8)}...${token.slice(-6)}`;
+}
+
+/**
+ * 명령행 인자 또는 환경 변수에서 테스트 대상 사용자 UID를 읽습니다.
+ * @returns 사용자 UID
+ */
+function getTargetUserId(): string {
+  const positionalArgument = process.argv
+      .slice(2)
+      .find((argument) => !argument.startsWith("--"));
+  const userId =
+    positionalArgument?.trim() ||
+    process.env.TEST_NOTIFICATION_USER_ID?.trim();
+
+  if (!userId) {
+    throw new Error(
+        "User ID is required. Run " +
+        "`npm run notification:test -- <user-id>` or set " +
+        "TEST_NOTIFICATION_USER_ID in .env.",
+    );
+  }
+  return userId;
+}
+
+/**
+ * Realtime Database에서 사용자와 FCM 토큰을 조회해 테스트 알림을 보냅니다.
+ */
+async function main(): Promise<void> {
+  const userId = getTargetUserId();
+  const dryRun = process.argv.includes("--dry-run");
+  const title =
+    process.env.TEST_NOTIFICATION_TITLE?.trim() ||
+    "🔔 하루한컷 테스트 알림";
+  const body =
+    process.env.TEST_NOTIFICATION_BODY?.trim() ||
+    "Cloud Functions TypeScript에서 보낸 테스트 알림입니다.";
+  const app = initializeFirebaseAdmin();
+
+  try {
+    const snapshot = await admin.database()
+        .ref(`/users/${userId}`)
+        .once("value");
+    const user = snapshot.val() as UserData | null;
+
+    if (!user || typeof user !== "object") {
+      throw new Error(`User not found: ${userId}`);
+    }
+
+    const nickname =
+      typeof user.nickname === "string" && user.nickname.trim() ?
+        user.nickname.trim() :
+        "알 수 없는 사용자";
+
+    if (user.isPushEnabled !== true) {
+      throw new Error(`${nickname} 사용자는 알림 설정이 꺼져 있습니다.`);
+    }
+
+    const token =
+      typeof user.fcmToken === "string" ?
+        user.fcmToken.trim() :
+        "";
+
+    if (invalidTokens.has(token)) {
+      throw new Error(`${nickname} 사용자의 유효한 FCM 토큰이 없습니다.`);
+    }
+
+    console.log(`➡️ 사용자: ${nickname}`);
+    console.log(`➡️ FCM 토큰: ${maskToken(token)}`);
+    console.log(`➡️ 전송 모드: ${dryRun ? "검증만 수행" : "실제 전송"}`);
+
+    const messageId = await admin.messaging().send(
+        {
+          token,
+          notification: {
+            title,
+            body,
+          },
+          data: {
+            type: "test",
+            userId,
+          },
+          apns: {
+            headers: {
+              "apns-priority": "10",
+              "apns-push-type": "alert",
+            },
+            payload: {
+              aps: {
+                sound: "default",
+              },
+            },
+          },
+        },
+        dryRun,
+    );
+
+    console.log(
+        `${dryRun ? "✅ FCM 메시지 검증 성공" : "✅ FCM 전송 요청 성공"}: ` +
+        messageId,
+    );
+  } finally {
+    await app.delete();
+  }
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ 테스트 알림 처리 실패: ${message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- `firebase/functions-typescript`에서 단건 테스트 알림과 전체 공지를 실행할 수 있는 npm script를 추가했습니다.
- 단건 전송은 사용자 UID로 Realtime Database의 최신 사용자 정보와 FCM 토큰을 조회합니다.
- 전체 공지는 알림이 활성화되고 유효한 FCM 토큰이 있는 사용자만 선별하며, 중복 토큰을 제거합니다.
- FCM 제한에 맞춰 수신 대상을 최대 500개 단위로 나누어 `sendEachForMulticast`로 전송합니다.
- 두 전송 방식 모두 APNs `alert`, 우선순위, 기본 알림음을 포함합니다.
- Firebase 초기화, 토큰 검증, 토큰 마스킹, APNs 설정은 `notification-utils.ts`에서 공통으로 관리합니다.
- 실제 알림 없이 Firebase 인증·DB 조회·메시지 구성을 확인할 수 있도록 `--dry-run`을 지원합니다.
- 전체 공지의 실수 전송을 막기 위해 실제 전송에는 `--confirm`을 요구합니다.

## 🚨 관련 이슈

- close #73

## 🎨 스크린샷

UI 변경 없음

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

### 실행 위치

두 파일은 Firebase에 배포해서 이벤트로 실행하는 Cloud Function이 아닙니다.
로컬 Mac의 Node.js가 스크립트를 실행하고, Cloud Functions에서 사용하는 것과
같은 Firebase Admin SDK와 인증 환경으로 Realtime Database와 FCM에 요청합니다.

```text
로컬 Node.js
    ↓ Firebase Admin SDK
Realtime Database에서 사용자와 FCM 토큰 조회
    ↓
Firebase Cloud Messaging
    ↓
Apple Push Notification service
    ↓
iPhone
```

### `npm run notification:test -- <사용자 UID>`가 실행되는 과정

`package.json`에는 다음 npm script가 등록돼 있습니다.

```json
"notification:test": "npm run build && node lib/scripts/send-test-notification.js"
```

명령을 실행하면 다음 순서로 처리됩니다.

```text
[1] npm이 package.json에서 notification:test를 찾음
    ↓
[2] npm run build로 TypeScript 컴파일
    src/scripts/*.ts → lib/scripts/*.js
    ↓
[3] 컴파일에 성공하면 Node.js로 JavaScript 실행
    ↓
[4] -- 뒤의 사용자 UID를 process.argv로 전달
    ↓
[5] /users/{UID}에서 최신 사용자 정보 조회
    ↓
[6] isPushEnabled와 fcmToken 검사
    ↓
[7] FCM 메시지 전송
    ↓
[8] FCM이 APNs를 거쳐 iPhone에 알림 전달
```

`--`는 뒤의 값을 npm 옵션으로 처리하지 않고 Node.js 실행 파일에 전달하는
구분자입니다. 전달하는 값은 FCM 토큰이 아니라 Firebase 사용자 UID입니다.
스크립트가 UID로 Realtime Database를 조회해 서버에 저장된 최신 FCM 토큰을
찾기 때문에 토큰을 직접 복사할 필요가 없습니다.

### 공통 Firebase 초기화와 APNs 설정

두 실행 파일은 `notification-utils.ts`를 함께 사용합니다.

```text
firebase/functions-typescript/.env
    ├─ Firebase 프로젝트 ID
    ├─ Realtime Database URL
    └─ 서비스 계정 인증 정보
            ↓
    Firebase Admin SDK 초기화
            ↓
    토큰 검사 + 토큰 로그 마스킹 + APNs 설정
```

APNs 메시지에는 다음 설정을 포함합니다.

- `apns-push-type: alert`: 사용자 화면에 표시하는 알림
- `apns-priority: 10`: APNs에 즉시 전달 요청
- `sound: default`: iPhone 기본 알림음 재생

### 단건 테스트 알림 알고리즘

```text
사용자 UID 입력
    ↓
/users/{UID} 조회
    ↓
사용자 존재 여부 확인
    ↓
isPushEnabled == true 확인
    ↓
fcmToken 유효성 확인
    ↓
messaging.send()로 한 개 토큰에 전송
```

### 전체 공지 알고리즘

```text
/users 전체 조회
    ↓
isPushEnabled == true인 사용자만 선택
    ↓
비어 있거나 noFCM, noToken인 토큰 제외
    ↓
중복 FCM 토큰 제거
    ↓
최대 500개 단위로 분할
    ↓
sendEachForMulticast()로 일괄 전송
    ↓
사용자별 성공·실패 집계
```

### 특정 사용자에게 테스트 알림 전송

```bash
cd firebase/functions-typescript
npm run notification:test -- <사용자 UID>
```

로컬 `.env`에 `TEST_NOTIFICATION_USER_ID`를 지정하면 UID를 생략할 수 있습니다.
제목과 본문은 각각 `TEST_NOTIFICATION_TITLE`, `TEST_NOTIFICATION_BODY`로 변경할 수 있습니다.

실제 알림을 보내지 않고 검증만 하려면 다음과 같이 실행합니다.

```bash
npm run notification:test -- <사용자 UID> --dry-run
```

### 전체 공지 검증

아래 명령은 모든 수신 대상의 FCM 메시지를 검증하지만 실제 기기에는 알림을 보내지 않습니다.

```bash
npm run notification:announcement -- \
  --title "공지 제목" \
  --body "공지 내용" \
  --dry-run
```

### 전체 공지 실제 전송

dry-run 결과를 확인한 뒤 `--confirm`으로 실제 전송합니다.

```bash
npm run notification:announcement -- \
  --title "공지 제목" \
  --body "공지 내용" \
  --confirm
```

제목과 본문은 로컬 `.env`의 `ANNOUNCEMENT_TITLE`, `ANNOUNCEMENT_BODY`로도 설정할 수 있습니다.
본문에서 줄바꿈이 필요하면 `\n`을 사용할 수 있습니다.

### 검증

- `npm run lint`
- `npm run build`
- 기존 테스트 사용자에 대한 단건 `--dry-run` 성공
- 전체 공지 `--dry-run`: 성공 31건, 실패 0건

PR 준비 과정에서는 실제 기기 알림을 전송하지 않았습니다.
