### PR TITLE
[#79] 가족 사진이 개인의 오늘 업로드 완료 상태로 처리되는 문제

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,6 +41,12 @@ permissions:
   issues: write
   pull-requests: write
 
+# 같은 PR/브랜치에 새 커밋이 올라오면 이전 CI를 취소하고 최신 실행만 검사한다.
+# PR 댓글 명령어로 실행한 경우에는 입력된 PR 번호를 같은 그룹 키로 사용한다.
+concurrency:
+  group: haruhancut-build-and-test-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   XCODE_VERSION: "26.3"
   SIMULATOR_NAME: "iPhone 16"

--- a/Projects/Features/HomeFeatureV2/Demo/Sources/DemoDependencies.swift
+++ b/Projects/Features/HomeFeatureV2/Demo/Sources/DemoDependencies.swift
@@ -7,6 +7,7 @@
 
 import Core
 import Domain
+import Kingfisher
 import RxSwift
 import UIKit
 
@@ -347,6 +348,13 @@ private final class DemoGroupUsecase:
         }
 
         let postID = UUID().uuidString
+        let imageURL =
+            "https://demo.haruhancut.local/uploads/\(postID)"
+        ImageCache.default.store(
+            image,
+            forKey: imageURL,
+            toDisk: false
+        )
         upsert(
             Post(
                 postId: postID,
@@ -354,10 +362,7 @@ private final class DemoGroupUsecase:
                 nickname: user.nickname,
                 profileImageURL:
                     user.profileImageURL,
-                imageURL:
-                    DemoContent.imageURL(
-                        seed: postID
-                    ),
+                imageURL: imageURL,
                 createdAt: .now,
                 likeCount: 0,
                 comments: [:]
@@ -484,7 +489,8 @@ private enum DemoContent {
             makePost(
                 id: "today-morning",
                 user: user,
-                nickname: "하루",
+                authorID: "demo-family-one",
+                nickname: "가족 1",
                 seed: "morning",
                 date: now.addingTimeInterval(
                     -60 * 8
@@ -493,7 +499,8 @@ private enum DemoContent {
             makePost(
                 id: "today-walk",
                 user: user,
-                nickname: "하루",
+                authorID: "demo-family-one",
+                nickname: "가족 1",
                 seed: "walk",
                 date: now.addingTimeInterval(
                     -60 * 35
@@ -502,7 +509,8 @@ private enum DemoContent {
             makePost(
                 id: "today-coffee",
                 user: user,
-                nickname: "한컷",
+                authorID: "demo-family-two",
+                nickname: "가족 2",
                 seed: "coffee",
                 date: now.addingTimeInterval(
                     -60 * 90
@@ -511,7 +519,8 @@ private enum DemoContent {
             makePost(
                 id: "today-sunset",
                 user: user,
-                nickname: "한컷",
+                authorID: "demo-family-two",
+                nickname: "가족 2",
                 seed: "sunset",
                 date: now.addingTimeInterval(
                     -60 * 180
@@ -558,6 +567,10 @@ private enum DemoContent {
             members: [
                 user.uid:
                     user.nickname,
+                "demo-family-one":
+                    "가족 1",
+                "demo-family-two":
+                    "가족 2",
             ],
             postsByDate: postsByDate
         )
@@ -572,6 +585,7 @@ private enum DemoContent {
     private static func makePost(
         id: String,
         user: User,
+        authorID: String? = nil,
         nickname: String,
         seed: String,
         date: Date
@@ -587,7 +601,7 @@ private enum DemoContent {
 
         return Post(
             postId: id,
-            userId: user.uid,
+            userId: authorID ?? user.uid,
             nickname: nickname,
             profileImageURL:
                 user.profileImageURL,

--- a/Projects/Features/HomeFeatureV2/Demo/Sources/DemoHomeRouter.swift
+++ b/Projects/Features/HomeFeatureV2/Demo/Sources/DemoHomeRouter.swift
@@ -5,10 +5,12 @@
 //  Created by 김동현 on 7/27/26.
 //
 
+import Core
 import Domain
 import Foundation
 import HomeFeatureV2
 import HomeFeatureV2Interface
+import RxSwift
 import UIKit
 
 final class DemoHomeRouter:
@@ -28,6 +30,9 @@ final class DemoHomeRouter:
 
     private weak var navigationController:
         UINavigationController?
+    @Dependency private var groupUsecase:
+        GroupUsecaseProtocol
+    private let disposeBag = DisposeBag()
 
     init(
         navigationController:
@@ -79,16 +84,16 @@ final class DemoHomeRouter:
         }
         onCameraTapped = {
             [weak self] source in
-            let title: String
             switch source {
             case .camera:
-                title = "카메라"
+                self?.presentImagePicker(
+                    sourceType: .camera
+                )
             case .album:
-                title = "앨범"
+                self?.presentImagePicker(
+                    sourceType: .photoLibrary
+                )
             }
-            self?.showDemoNotice(
-                title: title
-            )
         }
         onMemberTapped = {
             [weak self] in
@@ -243,6 +248,35 @@ final class DemoHomeRouter:
             )
     }
 
+    private func presentImagePicker(
+        sourceType:
+            UIImagePickerController.SourceType
+    ) {
+        guard
+            UIImagePickerController
+                .isSourceTypeAvailable(
+                    sourceType
+                )
+        else {
+            showDemoNotice(
+                title:
+                    "이 기기에서는 사용할 수 없습니다."
+            )
+            return
+        }
+
+        let picker =
+            UIImagePickerController()
+        picker.sourceType = sourceType
+        picker.allowsEditing = false
+        picker.delegate = self
+        navigationController?
+            .present(
+                picker,
+                animated: true
+            )
+    }
+
     @objc
     private func didTapMember() {
         onMemberTapped?()
@@ -251,6 +285,66 @@ final class DemoHomeRouter:
     @objc
     private func didTapProfile() {
         onProfileTapped?()
+    }
+}
+
+extension DemoHomeRouter:
+    UIImagePickerControllerDelegate,
+    UINavigationControllerDelegate
+{
+    func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info:
+            [UIImagePickerController.InfoKey: Any]
+    ) {
+        guard
+            let image =
+                info[.originalImage]
+                as? UIImage
+        else {
+            picker.dismiss(
+                animated: true
+            )
+            return
+        }
+
+        groupUsecase
+            .uploadImageAndUploadPost(
+                image: image
+            )
+            .observe(
+                on:
+                    MainScheduler.instance
+            )
+            .subscribe(
+                onNext: {
+                    picker.dismiss(
+                        animated: true
+                    )
+                },
+                onError: {
+                    [weak self] _ in
+                    picker.dismiss(
+                        animated: true
+                    ) {
+                        self?.showDemoNotice(
+                            title:
+                                "업로드에 실패했습니다."
+                        )
+                    }
+                }
+            )
+            .disposed(
+                by: disposeBag
+            )
+    }
+
+    func imagePickerControllerDidCancel(
+        _ picker: UIImagePickerController
+    ) {
+        picker.dismiss(
+            animated: true
+        )
     }
 }
 

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedReactor.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedReactor.swift
@@ -29,13 +29,17 @@ final class FeedReactor: Reactor {
     enum Mutation {
         case setUser(User)
         case setLoading(Bool)
-        case setComponents([FeedComponent])
+        case setFeed(
+            components: [FeedComponent],
+            didTodayUpload: Bool
+        )
     }
 
     struct State {
         var user: User?
         var isLoading: Bool = false
         var components: [FeedComponent] = []
+        var didTodayUpload: Bool = false
     }
 
     let initialState = State()
@@ -76,8 +80,9 @@ final class FeedReactor: Reactor {
             state.user = user
         case .setLoading(let isLoading):
             state.isLoading = isLoading
-        case .setComponents(let components):
+        case .setFeed(let components, let didTodayUpload):
             state.components = components
+            state.didTodayUpload = didTodayUpload
         }
         return state
     }
@@ -99,9 +104,14 @@ private extension FeedReactor {
             return .empty()
         }
         let previousComponents = currentState.components
+        let previousDidTodayUpload = currentState.didTodayUpload
         let remainingComponents = previousComponents.filter {
             $0.post.postId != post.postId
         }
+        let remainingDidTodayUpload = Self.didTodayUpload(
+            in: remainingComponents,
+            currentUserID: userSession.userId
+        )
 
         let synchronizeDeletion = groupUsecase
             .deletePostAndReload(post: post)
@@ -109,10 +119,8 @@ private extension FeedReactor {
             .flatMap { [weak self] _ -> Observable<Mutation> in
                 guard let self else { return .empty() }
                 return .just(
-                    .setComponents(
-                        self.makeComponents(
-                            from: self.groupSession.postsByDate
-                        )
+                    self.makeFeedMutation(
+                        from: self.groupSession.postsByDate
                     )
                 )
             }
@@ -121,13 +129,21 @@ private extension FeedReactor {
                     "FeedReactor deletePostAndReload failed: \(error)"
                 )
                 return .just(
-                    .setComponents(previousComponents)
+                    .setFeed(
+                        components: previousComponents,
+                        didTodayUpload: previousDidTodayUpload
+                    )
                 )
             }
 
         return Observable.concat([
             .just(.setLoading(true)),
-            .just(.setComponents(remainingComponents)),
+            .just(
+                .setFeed(
+                    components: remainingComponents,
+                    didTodayUpload: remainingDidTodayUpload
+                )
+            ),
             synchronizeDeletion,
             .just(.setLoading(false))
         ])
@@ -146,7 +162,7 @@ private extension FeedReactor {
         let loadGroup: Observable<Mutation> =
             loadGroup()
             .map { group -> Mutation in
-                Mutation.setComponents(self.makeComponents(from: group.postsByDate))
+                self.makeFeedMutation(from: group.postsByDate)
             }
             .catch { error in
                 Logger.e("FeedReactor loadAndFetchGroup failed: \(error)")
@@ -157,11 +173,36 @@ private extension FeedReactor {
         return Observable.merge([loadUser, loadGroup])
     }
 
-    func makeComponents(from postsByDate: [String: [Post]]) -> [FeedComponent] {
+    func makeFeedMutation(from postsByDate: [String: [Post]]) -> Mutation {
+        let components = Self.makeComponents(from: postsByDate)
+        return .setFeed(
+            components: components,
+            didTodayUpload: Self.didTodayUpload(
+                in: components,
+                currentUserID: userSession.userId
+            )
+        )
+    }
+}
+
+extension FeedReactor {
+    static func makeComponents(
+        from postsByDate: [String: [Post]]
+    ) -> [FeedComponent] {
         postsByDate.values
             .flatMap { $0 }
             .sorted { $0.createdAt > $1.createdAt }
             .filter { $0.isToday }
             .map { FeedComponent(post: $0) }
+    }
+
+    static func didTodayUpload(
+        in components: [FeedComponent],
+        currentUserID: String?
+    ) -> Bool {
+        guard let currentUserID else { return false }
+        return components.contains {
+            $0.post.userId == currentUserID
+        }
     }
 }

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedView.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedView.swift
@@ -17,7 +17,7 @@ final class FeedView: UIView {
             collectionViewLayout:
                 UICollectionViewFlowLayout()
         )
-        collectionView.backgroundColor = .background
+        collectionView.backgroundColor = .clear
         collectionView.showsVerticalScrollIndicator = false
         collectionView.alwaysBounceVertical = true
         collectionView.accessibilityIdentifier = UITestID.Feed.collectionView
@@ -60,10 +60,31 @@ final class FeedView: UIView {
 
     private func setupUI() {
         backgroundColor = .background
-        [collectionView, cameraBtn, bubbleView, emptyLabel].forEach {
+        [cameraBtn, bubbleView, collectionView, emptyLabel].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
+    }
+
+    override func hitTest(
+        _ point: CGPoint,
+        with event: UIEvent?
+    ) -> UIView? {
+        let cameraButtonPoint = convert(
+            point,
+            to: cameraBtn
+        )
+        if let hitView = cameraBtn.hitTest(
+            cameraButtonPoint,
+            with: event
+        ) {
+            return hitView
+        }
+
+        return super.hitTest(
+            point,
+            with: event
+        )
     }
 
     private func setupConstraints() {

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedViewController.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedViewController.swift
@@ -90,12 +90,21 @@ final class FeedViewController: UIViewController, View {
             .distinctUntilChanged()
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, components in
-                owner.render(components: components)
+                owner.renderFeed(components: components)
+            }
+            .disposed(by: disposeBag)
+
+        reactor.state
+            .map(\.didTodayUpload)
+            .distinctUntilChanged()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, didTodayUpload in
+                owner.renderUploadState(didTodayUpload: didTodayUpload)
             }
             .disposed(by: disposeBag)
     }
 
-    private func render(components: [FeedComponent]) {
+    private func renderFeed(components: [FeedComponent]) {
         let shouldAnimate = !currentComponents.isEmpty
         currentComponents = components
 
@@ -129,11 +138,14 @@ final class FeedViewController: UIViewController, View {
             ? LocalizationKey.adminPreviewEmpty.localized
             : LocalizationKey.homeDescription.localized
         customView.emptyLabel.isHidden = hasContent
-        customView.bubbleView.text = hasContent
+    }
+
+    private func renderUploadState(didTodayUpload: Bool) {
+        customView.bubbleView.text = didTodayUpload
             ? LocalizationKey.homeFeedBubbleDoneToday.localized
             : LocalizationKey.homeFeedBubbleAddPhoto.localized
 
-        let canAddPhoto = !hasContent || ProcessInfo.processInfo.arguments.contains("-UITest")
+        let canAddPhoto = !didTodayUpload || ProcessInfo.processInfo.arguments.contains("-UITest")
         customView.cameraBtn.isEnabled = !isReadOnly && canAddPhoto
         customView.cameraBtn.alpha = canAddPhoto ? 1.0 : 0.3
     }

--- a/Projects/Features/HomeFeatureV2/Tests/Sources/FeedUploadStateTests.swift
+++ b/Projects/Features/HomeFeatureV2/Tests/Sources/FeedUploadStateTests.swift
@@ -1,0 +1,68 @@
+@testable import HomeFeatureV2
+import Domain
+import XCTest
+
+final class FeedUploadStateTests: XCTestCase {
+    private let currentUserID = "current-user"
+
+    func testFamilyPostDoesNotMarkCurrentUserUploadAsComplete() {
+        let components = makeComponents(
+            posts: [makePost(id: "family-post", userID: "family-user")]
+        )
+
+        XCTAssertEqual(components.map(\.post.postId), ["family-post"])
+        XCTAssertFalse(
+            FeedReactor.didTodayUpload(
+                in: components,
+                currentUserID: currentUserID
+            )
+        )
+    }
+
+    func testCurrentUserPostMarksUploadAsComplete() {
+        let components = makeComponents(
+            posts: [makePost(id: "my-post", userID: currentUserID)]
+        )
+
+        XCTAssertTrue(
+            FeedReactor.didTodayUpload(
+                in: components,
+                currentUserID: currentUserID
+            )
+        )
+    }
+
+    func testFamilyAndCurrentUserPostsRemainVisibleWithCurrentUserUploadComplete() {
+        let components = makeComponents(
+            posts: [
+                makePost(id: "family-post", userID: "family-user"),
+                makePost(id: "my-post", userID: currentUserID),
+            ]
+        )
+
+        XCTAssertEqual(Set(components.map(\.post.postId)), ["family-post", "my-post"])
+        XCTAssertTrue(
+            FeedReactor.didTodayUpload(
+                in: components,
+                currentUserID: currentUserID
+            )
+        )
+    }
+
+    private func makeComponents(posts: [Post]) -> [FeedComponent] {
+        FeedReactor.makeComponents(from: ["today": posts])
+    }
+
+    private func makePost(id: String, userID: String) -> Post {
+        Post(
+            postId: id,
+            userId: userID,
+            nickname: userID,
+            profileImageURL: nil,
+            imageURL: "https://example.com/\(id).jpg",
+            createdAt: .now,
+            likeCount: 0,
+            comments: [:]
+        )
+    }
+}

--- a/Projects/Features/HomeFeatureV2/Tests/Sources/FeedViewLayerTests.swift
+++ b/Projects/Features/HomeFeatureV2/Tests/Sources/FeedViewLayerTests.swift
@@ -1,0 +1,84 @@
+@testable import HomeFeatureV2
+import XCTest
+
+final class FeedViewLayerTests: XCTestCase {
+    func testFeedGridIsLayeredAboveUploadControls() {
+        let view =
+            FeedView(
+                frame: CGRect(
+                    x: 0,
+                    y: 0,
+                    width: 390,
+                    height: 844
+                )
+            )
+
+        let cameraButtonIndex =
+            tryUnwrap(
+                view.subviews.firstIndex(
+                    of: view.cameraBtn
+                )
+            )
+        let bubbleViewIndex =
+            tryUnwrap(
+                view.subviews.firstIndex(
+                    of: view.bubbleView
+                )
+            )
+        let collectionViewIndex =
+            tryUnwrap(
+                view.subviews.firstIndex(
+                    of: view.collectionView
+                )
+            )
+
+        XCTAssertGreaterThan(
+            collectionViewIndex,
+            cameraButtonIndex
+        )
+        XCTAssertGreaterThan(
+            collectionViewIndex,
+            bubbleViewIndex
+        )
+        XCTAssertEqual(
+            view.collectionView.backgroundColor,
+            .clear
+        )
+    }
+
+    func testCameraButtonReceivesTouchAboveFeedGrid() {
+        let view =
+            FeedView(
+                frame: CGRect(
+                    x: 0,
+                    y: 0,
+                    width: 390,
+                    height: 844
+                )
+            )
+        view.layoutIfNeeded()
+
+        let hitView =
+            view.hitTest(
+                view.cameraBtn.center,
+                with: nil
+            )
+
+        XCTAssertTrue(
+            hitView === view.cameraBtn ||
+                hitView?.isDescendant(
+                    of: view.cameraBtn
+                ) == true
+        )
+    }
+
+    private func tryUnwrap(
+        _ value: Int?
+    ) -> Int {
+        guard let value else {
+            XCTFail("필수 뷰가 계층에 없습니다.")
+            return -1
+        }
+        return value
+    }
+}


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [x] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- 가족 전체의 오늘 피드와 현재 사용자의 오늘 업로드 상태를 분리했습니다.
- 현재 사용자의 `userId`와 일치하는 오늘 사진이 있을 때만 `오늘 사진 추가 완료`를 표시합니다.
- 현재 사용자가 오늘 사진을 올린 경우에만 카메라 버튼을 비활성화합니다.
- 게시물 삭제 시 개인 업로드 상태도 함께 낙관적으로 갱신하고, 실패하면 이전 상태로 복원합니다.
- 가족만 업로드한 경우, 본인만 업로드한 경우, 두 사용자가 함께 업로드한 경우를 검증하는 회귀 테스트를 추가했습니다.

## 🚨 관련 이슈

- Closes #79

## 🎨 스크린샷

| 기능 | 스크린샷 |
| :--: | :------: |
| 개인별 오늘 업로드 상태 | 로직 및 회귀 테스트 변경으로 생략 |

## ✅ 체크리스트

- [x] 코드와 커밋이 저장소 컨벤션을 따릅니다.
- [ ] PR의 Assignees와 Reviewers를 설정했습니다.
- [x] 불필요한 코드를 제외하고 정상 동작을 검증했습니다.
- [x] 관련 이슈 번호를 작성했습니다.

## 🔥 추가 설명

### 원인

`FeedReactor`가 가족 전체의 오늘 게시물을 `components`로 만들고, `FeedViewController`가 `components.isEmpty`를 개인의 업로드 완료 여부로 사용했습니다. 가족 중 한 명만 사진을 올려도 모든 구성원에게 완료 문구가 표시되고 카메라 버튼이 비활성화됐습니다.

### 검증

- `tuist test HomeFeatureV2`: 7개 테스트 통과
- `xcodebuild build -workspace Haruhancut.xcworkspace -scheme App -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`: App 빌드 성공


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 오늘 사용자의 업로드 여부를 피드에 반영합니다.
  - 업로드 완료 상태에 따라 안내 문구와 카메라 버튼이 표시·활성화됩니다.
  - 카메라와 앨범에서 이미지를 선택해 게시물을 업로드할 수 있습니다.
  - 피드 로드 및 삭제 시 콘텐츠와 업로드 상태가 함께 갱신됩니다.

- **버그 수정**
  - 피드 삭제 실패 시 콘텐츠와 업로드 상태가 이전 상태로 정확히 복원됩니다.

- **테스트**
  - 가족 게시물과 사용자 게시물이 섞인 다양한 피드 상황에서 업로드 상태를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->