### PR TITLE
[#83] 프로필 그리드 이미지 프리패치와 캐시 데모를 개선한다

### DIFF
--- a/Projects/Coordinator/Sources/ProfileCoordinatorV2.swift
+++ b/Projects/Coordinator/Sources/ProfileCoordinatorV2.swift
@@ -48,10 +48,13 @@ public final class ProfileCoordinatorV2: NSObject, Coordinator {
             profilePresentImagePicker(completion: completion)
         }
         
-        profile.vm.onImageTapped = { [weak self] post in
+        profile.vm.onImageTapped = { [weak self] selection in
             guard let self = self else { return }
             let builder = HomeFeatureV2.FeedDetailBuilder()
-            var feedDetail = builder.makeFeed(post: post)
+            var feedDetail = builder.makeFeed(
+                post: selection.post,
+                initialImage: selection.previewImage
+            )
             let feedDetailViewController: UIViewController & RefreshableViewController = feedDetail.vc
             profileViewController?.navigationItem.backButtonDisplayMode = .minimal
             self.navigationController.pushViewController(feedDetailViewController, animated: true)

--- a/Projects/Data/Sources/FirebaseStorageManager.swift
+++ b/Projects/Data/Sources/FirebaseStorageManager.swift
@@ -10,7 +10,11 @@ import FirebaseStorage
 import RxSwift
 
 public protocol FirebaseStorageManagerProtocol {
-    func uploadImage(image: UIImage, path: String) -> Single<URL>
+    func uploadImage(
+        image: UIImage,
+        path: String,
+        compressionQuality: CGFloat
+    ) -> Single<URL>
     func deleteImage(path: String) -> Single<Void>
 }
 
@@ -19,9 +23,17 @@ public final class FirebaseStorageManager: FirebaseStorageManagerProtocol {
 }
 
 extension FirebaseStorageManager {
-    public func uploadImage(image: UIImage, path: String) -> Single<URL> {
+    public func uploadImage(
+        image: UIImage,
+        path: String,
+        compressionQuality: CGFloat
+    ) -> Single<URL> {
         return Single.create { single in
-            guard let data = image.jpegData(compressionQuality: 0.8) else {
+            let quality = min(
+                max(compressionQuality, 0),
+                1
+            )
+            guard let data = image.jpegData(compressionQuality: quality) else {
                 print("❌ JPEG 변환 실패")
                 single(.failure(FirebaseError.encodingFailed))
                 return Disposables.create()

--- a/Projects/Data/Sources/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/Projects/Data/Sources/RepositoryImpl/AuthRepositoryImpl.swift
@@ -111,7 +111,11 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
     
     public func uploadImage(user: User, image: UIImage) -> Single<URL> {
         let path = "users/\(user.uid)/profile.jpg"
-        return firebaseStorageManager.uploadImage(image: image, path: path)
+        return firebaseStorageManager.uploadImage(
+            image: image,
+            path: path,
+            compressionQuality: 0.8
+        )
     }
     
     public func generateFcmToken() -> Single<String> {

--- a/Projects/Data/Sources/RepositoryImpl/GroupRepositoryImpl.swift
+++ b/Projects/Data/Sources/RepositoryImpl/GroupRepositoryImpl.swift
@@ -65,8 +65,16 @@ public final class GroupRepositoryImpl: GroupRepositoryProtocol {
     
     
     // Image
-    public func uploadImage(image: UIImage, path: String) -> Single<URL> {
-        return firebaseStorageManager.uploadImage(image: image, path: path)
+    public func uploadImage(
+        image: UIImage,
+        path: String,
+        compressionQuality: CGFloat
+    ) -> Single<URL> {
+        return firebaseStorageManager.uploadImage(
+            image: image,
+            path: path,
+            compressionQuality: compressionQuality
+        )
     }
     
     public func deleteImage(path: String) -> Single<Void> {

--- a/Projects/Domain/Sources/RepositoryProtocol/GroupRepositoryProtocol.swift
+++ b/Projects/Domain/Sources/RepositoryProtocol/GroupRepositoryProtocol.swift
@@ -22,7 +22,11 @@ public protocol GroupRepositoryProtocol {
     func fetchGroup(groupId: String) -> Single<HCGroup>
     
     // Image
-    func uploadImage(image: UIImage, path: String) -> Single<URL>
+    func uploadImage(
+        image: UIImage,
+        path: String,
+        compressionQuality: CGFloat
+    ) -> Single<URL>
     func deleteImage(path: String) -> Single<Void>
     
     // Comment

--- a/Projects/Domain/Sources/Usecase/GroupUsecase.swift
+++ b/Projects/Domain/Sources/Usecase/GroupUsecase.swift
@@ -237,7 +237,11 @@ public final class GroupUsecaseImpl: GroupUsecaseProtocol {
         let storagePath = "groups/\(groupId)/images/\(postId).jpg"         // storage  저장 위치
         let dbPath = "groups/\(groupId)/postsByDate/\(dateKey)/\(postId)"  // realtime 저장 위치
         
-        return groupRepository.uploadImage(image: image, path: storagePath)
+        return groupRepository.uploadImage(
+            image: image,
+            path: storagePath,
+            compressionQuality: 1.0
+        )
             .asObservable()
             .flatMap { url -> Observable<Void> in
                 let post = Post(postId: postId,

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailBuilder.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailBuilder.swift
@@ -29,7 +29,19 @@ extension FeedDetailBuilder: FeedDetailBuildable {
     public func makeFeed(post: Post) -> FeedDetailPresentable {
         makeFeed(
             post: post,
-            mode: .currentGroup
+            mode: .currentGroup,
+            initialImage: nil
+        )
+    }
+
+    public func makeFeed(
+        post: Post,
+        initialImage: UIImage?
+    ) -> FeedDetailPresentable {
+        makeFeed(
+            post: post,
+            mode: .currentGroup,
+            initialImage: initialImage
         )
     }
 
@@ -37,6 +49,19 @@ extension FeedDetailBuilder: FeedDetailBuildable {
         post: Post,
         mode:
             HomePresentationMode
+    ) -> FeedDetailPresentable {
+        makeFeed(
+            post: post,
+            mode: mode,
+            initialImage: nil
+        )
+    }
+
+    private func makeFeed(
+        post: Post,
+        mode:
+            HomePresentationMode,
+        initialImage: UIImage?
     ) -> FeedDetailPresentable {
         @Dependency var groupUsecase: GroupUsecaseProtocol
         let loadGroup =
@@ -55,7 +80,8 @@ extension FeedDetailBuilder: FeedDetailBuildable {
             FeedDetailViewController(
                 viewModel: vm,
                 isReadOnly:
-                    mode.isReadOnly
+                    mode.isReadOnly,
+                initialImage: initialImage
             )
         return (vc, vm)
     }

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailView.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailView.swift
@@ -79,8 +79,11 @@ final class FeedDetailView: UIView {
 
         imageView.kf.cancelDownloadTask()
         currentImageURL = imageURL
+        
+        // 1. 프로필 그리드에서 넘겨받은 이미지 즉시 표시
         imageView.image = initialImage
 
+        // 2. 같은 URL로 원본 이미지 요청
         imageView.kf.setImage(
             with: url,
             options: [
@@ -96,5 +99,6 @@ final class FeedDetailView: UIView {
             }
             self?.currentImageURL = nil
         }
+        
     }
 }

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailView.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailView.swift
@@ -64,7 +64,10 @@ final class FeedDetailView: UIView {
         ])
     }
 
-    func configure(imageURL: String) {
+    func configure(
+        imageURL: String,
+        initialImage: UIImage?
+    ) {
         guard currentImageURL != imageURL else { return }
 
         guard let url = URL(string: imageURL) else {
@@ -76,6 +79,7 @@ final class FeedDetailView: UIView {
 
         imageView.kf.cancelDownloadTask()
         currentImageURL = imageURL
+        imageView.image = initialImage
 
         imageView.kf.setImage(
             with: url,

--- a/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailViewController.swift
+++ b/Projects/Features/HomeFeatureV2/Sources/Feed/FeedDetail/FeedDetailViewController.swift
@@ -23,16 +23,19 @@ final class FeedDetailViewController: UIViewController, RefreshableViewControlle
     private let reloadRelay = PublishRelay<Void>()
     private let isReadOnly:
         Bool
+    private let initialImage: UIImage?
 
     init(
         viewModel: FeedDetailViewModel,
         isReadOnly:
-            Bool = false
+            Bool = false,
+        initialImage: UIImage? = nil
     ) {
         self.viewModel = viewModel
         self.customView = FeedDetailView()
         self.isReadOnly =
             isReadOnly
+        self.initialImage = initialImage
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -83,7 +86,10 @@ final class FeedDetailViewController: UIViewController, RefreshableViewControlle
 
         output.imageURL
             .drive(with: self, onNext: { owner, imageURL in
-                owner.customView.configure(imageURL: imageURL)
+                owner.customView.configure(
+                    imageURL: imageURL,
+                    initialImage: owner.initialImage
+                )
             })
             .disposed(by: disposeBag)
 

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -1,0 +1,373 @@
+import Kingfisher
+import ProfileFeatureV2
+import UIKit
+
+/// 프로필 그리드의 다운샘플링, 프리패치, 메모리/디스크 캐시를 손으로 검증하는 데모입니다.
+///
+/// Picsum의 seed URL을 사용하므로 페이지마다 서로 다른 원본 이미지를 요청하면서도,
+/// 다시 같은 페이지를 열면 같은 이미지로 캐시 동작을 확인할 수 있습니다.
+final class ProfileImageCacheDemoViewController:
+    UIViewController
+{
+    private enum Constant {
+        static let columnCount = 3
+        static let itemSpacing: CGFloat = 1
+        static let pageSize = 24
+        static let paginationThreshold = 9
+    }
+
+    private let imagePrefetchSession =
+        ProfileGridImagePrefetchSession()
+    private var items: [ProfileImageCacheDemoItem] = []
+    private var nextPage = 0
+    private var isAppendingPage = false
+    private var lastTargetWidth: CGFloat = 0
+
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: makeLayout()
+        )
+        collectionView.backgroundColor = .systemBackground
+        collectionView.alwaysBounceVertical = true
+        collectionView.isPrefetchingEnabled = true
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        collectionView.prefetchDataSource = self
+        collectionView.register(
+            ImageCell.self,
+            forCellWithReuseIdentifier: ImageCell.reuseIdentifier
+        )
+        return collectionView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "이미지 캐시 실험"
+        view.backgroundColor = .systemBackground
+        configureCollectionView()
+        configureNavigationItems()
+        appendNextPage()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let targetWidth = gridItemWidth
+        guard abs(lastTargetWidth - targetWidth) > 0.5 else {
+            return
+        }
+
+        lastTargetWidth = targetWidth
+        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.reloadData()
+    }
+
+    deinit {
+        imagePrefetchSession.stop()
+    }
+
+    private func configureCollectionView() {
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor
+            ),
+            collectionView.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor
+            ),
+            collectionView.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor
+            ),
+            collectionView.bottomAnchor.constraint(
+                equalTo: view.bottomAnchor
+            ),
+        ])
+    }
+
+    private func configureNavigationItems() {
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                title: "디스크",
+                style: .plain,
+                target: self,
+                action: #selector(clearDiskCache)
+            ),
+            UIBarButtonItem(
+                title: "메모리",
+                style: .plain,
+                target: self,
+                action: #selector(clearMemoryCache)
+            ),
+        ]
+        navigationItem.prompt =
+            "Picsum 무한 스크롤 · 프리패치 6개/동시 1개"
+    }
+
+    private func appendNextPage() {
+        guard !isAppendingPage else {
+            return
+        }
+
+        isAppendingPage = true
+        let page = nextPage
+        let newItems = (0..<Constant.pageSize).map {
+            index in
+            let id = "profile-cache-demo-\(page)-\(index)"
+            return ProfileImageCacheDemoItem(
+                id: id,
+                imageURL: URL(
+                    string:
+                        "https://picsum.photos/seed/\(id)/1200/1800"
+                )!
+            )
+        }
+        let startIndex = items.count
+        items.append(
+            contentsOf: newItems
+        )
+        nextPage += 1
+        isAppendingPage = false
+
+        collectionView.performBatchUpdates {
+            collectionView.insertItems(
+                at: newItems.indices.map {
+                    IndexPath(
+                        item: startIndex + $0,
+                        section: 0
+                    )
+                }
+            )
+        }
+    }
+
+    private func appendNextPageIfNeeded(
+        for itemIndex: Int
+    ) {
+        guard itemIndex >= items.count - Constant.paginationThreshold else {
+            return
+        }
+        appendNextPage()
+    }
+
+    private var gridItemWidth: CGFloat {
+        let availableWidth = max(
+            collectionView.bounds.width,
+            1
+        )
+        let totalSpacing = CGFloat(
+            Constant.columnCount - 1
+        ) * Constant.itemSpacing
+        return max(
+            (availableWidth - totalSpacing)
+                / CGFloat(Constant.columnCount),
+            1
+        )
+    }
+
+    private func makeLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout {
+            [weak self] _, _ in
+            let targetWidth = self?.gridItemWidth ?? 1
+            let item = NSCollectionLayoutItem(
+                layoutSize: NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .fractionalHeight(1)
+                )
+            )
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .absolute(targetWidth * 1.5)
+                ),
+                repeatingSubitem: item,
+                count: Constant.columnCount
+            )
+            group.interItemSpacing = .fixed(
+                Constant.itemSpacing
+            )
+
+            let section = NSCollectionLayoutSection(
+                group: group
+            )
+            section.interGroupSpacing = Constant.itemSpacing
+            return section
+        }
+    }
+
+    @objc
+    private func clearMemoryCache() {
+        ImageCache.default.clearMemoryCache()
+        imagePrefetchSession.stop()
+        collectionView.reloadData()
+        navigationItem.prompt = "메모리 캐시를 비웠습니다"
+    }
+
+    @objc
+    private func clearDiskCache() {
+        imagePrefetchSession.stop()
+        ImageCache.default.clearDiskCache {
+            [weak self] in
+            Task { @MainActor [weak self] in
+                self?.collectionView.reloadData()
+                self?.navigationItem.prompt =
+                    "디스크 캐시를 비웠습니다"
+            }
+        }
+    }
+}
+
+extension ProfileImageCacheDemoViewController:
+    UICollectionViewDataSource
+{
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        items.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard
+            let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: ImageCell.reuseIdentifier,
+                for: indexPath
+            ) as? ImageCell
+        else {
+            return UICollectionViewCell()
+        }
+
+        cell.configure(
+            item: items[indexPath.item],
+            targetWidth: gridItemWidth
+        )
+        return cell
+    }
+}
+
+extension ProfileImageCacheDemoViewController:
+    UICollectionViewDelegate
+{
+    func collectionView(
+        _ collectionView: UICollectionView,
+        willDisplay cell: UICollectionViewCell,
+        forItemAt indexPath: IndexPath
+    ) {
+        appendNextPageIfNeeded(
+            for: indexPath.item
+        )
+    }
+}
+
+extension ProfileImageCacheDemoViewController:
+    UICollectionViewDataSourcePrefetching
+{
+    func collectionView(
+        _ collectionView: UICollectionView,
+        prefetchItemsAt indexPaths: [IndexPath]
+    ) {
+        let requests: [ProfileGridImagePrefetchRequest] = indexPaths.compactMap {
+            indexPath in
+            guard items.indices.contains(indexPath.item) else {
+                return nil
+            }
+            let item = items[indexPath.item]
+            return ProfileGridImagePrefetchRequest(
+                postID: item.id,
+                imageURL: item.imageURL
+            )
+        }
+        imagePrefetchSession.prefetch(
+            requests,
+            targetWidth: gridItemWidth
+        )
+
+        if let furthestIndex = indexPaths.map(\.item).max() {
+            appendNextPageIfNeeded(
+                for: furthestIndex
+            )
+        }
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cancelPrefetchingForItemsAt indexPaths: [IndexPath]
+    ) {
+        let postIDs: [String] = indexPaths.compactMap {
+            indexPath in
+            guard items.indices.contains(indexPath.item) else {
+                return nil
+            }
+            return items[indexPath.item].id
+        }
+        imagePrefetchSession.cancelPrefetching(
+            postIDs: postIDs
+        )
+    }
+}
+
+private final class ImageCell: UICollectionViewCell {
+    static let reuseIdentifier = "profile-image-cache-demo-cell"
+
+    private let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray5
+        return imageView
+    }()
+
+    override init(
+        frame: CGRect
+    ) {
+        super.init(frame: frame)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(
+                equalTo: contentView.topAnchor
+            ),
+            imageView.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor
+            ),
+            imageView.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor
+            ),
+            imageView.bottomAnchor.constraint(
+                equalTo: contentView.bottomAnchor
+            ),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:)는 지원하지 않습니다.")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.kf.cancelDownloadTask()
+        imageView.image = nil
+    }
+
+    func configure(
+        item: ProfileImageCacheDemoItem,
+        targetWidth: CGFloat
+    ) {
+        imageView.kf.setImage(
+            with: item.imageURL,
+            options: ProfileGridImageRequest.options(
+                targetWidth: targetWidth
+            )
+        )
+    }
+}
+
+private struct ProfileImageCacheDemoItem: Hashable {
+    let id: String
+    let imageURL: URL
+}

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -1,4 +1,5 @@
 import Kingfisher
+import MachO
 import ProfileFeatureV2
 import UIKit
 
@@ -88,6 +89,12 @@ final class ProfileImageCacheDemoViewController:
 
     private func configureNavigationItems() {
         navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                title: "측정",
+                style: .plain,
+                target: self,
+                action: #selector(observeCacheClearMemory)
+            ),
             UIBarButtonItem(
                 title: "디스크",
                 style: .plain,
@@ -204,6 +211,48 @@ final class ProfileImageCacheDemoViewController:
         navigationItem.prompt = "메모리 캐시를 비웠습니다"
     }
 
+    /// 캐시 삭제가 즉시 프로세스 메모리 감소로 이어지지 않는 현상을 관찰합니다.
+    ///
+    /// 뷰에 표시 중인 이미지, allocator가 유지하는 힙 페이지, OS 메모리 회수 시점은
+    /// ImageCache와 별개입니다. 따라서 이 동작은 누수를 판정하지 않고,
+    /// 캐시 참조 삭제 전후의 `phys_footprint` 변화를 확인하는 데만 사용합니다.
+    @objc
+    private func observeCacheClearMemory() {
+        let footprintBefore = ProcessMemoryFootprint.current
+        imagePrefetchSession.stop()
+        ImageCache.default.clearMemoryCache()
+        navigationItem.prompt =
+            "캐시 삭제 후 메모리를 관찰하고 있습니다"
+
+        ImageCache.default.clearDiskCache {
+            [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    return
+                }
+                let footprintImmediatelyAfter =
+                    ProcessMemoryFootprint.current
+
+                DispatchQueue.main.asyncAfter(
+                    deadline: .now() + 1
+                ) {
+                    [weak self] in
+                    guard let self else {
+                        return
+                    }
+                    self.presentMemoryObservation(
+                        before: footprintBefore,
+                        immediatelyAfter:
+                            footprintImmediatelyAfter,
+                        delayedAfter:
+                            ProcessMemoryFootprint.current
+                    )
+                    self.collectionView.reloadData()
+                }
+            }
+        }
+    }
+
     @objc
     private func clearDiskCache() {
         imagePrefetchSession.stop()
@@ -215,6 +264,36 @@ final class ProfileImageCacheDemoViewController:
                     "디스크 캐시를 비웠습니다"
             }
         }
+    }
+
+    private func presentMemoryObservation(
+        before: UInt64,
+        immediatelyAfter: UInt64,
+        delayedAfter: UInt64
+    ) {
+        navigationItem.prompt =
+            "캐시 삭제 전후 footprint를 확인했습니다"
+        let alert = UIAlertController(
+            title: "캐시 삭제 메모리 관찰",
+            message: [
+                "삭제 전: \(before.memoryString)",
+                "삭제 직후: \(immediatelyAfter.memoryString)",
+                "1초 후: \(delayedAfter.memoryString)",
+                "",
+                "ImageCache 참조를 지워도 visible 이미지, allocator, OS 회수 시점 때문에 footprint가 바로 줄지 않거나 변동할 수 있습니다.",
+            ].joined(separator: "\n"),
+            preferredStyle: .alert
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: "확인",
+                style: .default
+            )
+        )
+        present(
+            alert,
+            animated: true
+        )
     }
 }
 
@@ -370,4 +449,43 @@ private final class ImageCell: UICollectionViewCell {
 private struct ProfileImageCacheDemoItem: Hashable {
     let id: String
     let imageURL: URL
+}
+
+private enum ProcessMemoryFootprint {
+    static var current: UInt64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.stride
+                / MemoryLayout<natural_t>.stride
+        )
+        let result = withUnsafeMutablePointer(
+            to: &info
+        ) {
+            pointer in
+            pointer.withMemoryRebound(
+                to: integer_t.self,
+                capacity: Int(count)
+            ) {
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(TASK_VM_INFO),
+                    $0,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return 0
+        }
+        return info.phys_footprint
+    }
+}
+
+private extension UInt64 {
+    var memoryString: String {
+        ByteCountFormatter.string(
+            fromByteCount: Int64(self),
+            countStyle: .memory
+        )
+    }
 }

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -131,21 +131,24 @@ final class ProfileImageCacheDemoViewController:
             )
         }
         let startIndex = items.count
-        items.append(
-            contentsOf: newItems
-        )
-        nextPage += 1
-        isAppendingPage = false
+        let indexPaths = newItems.indices.map {
+            IndexPath(
+                item: startIndex + $0,
+                section: 0
+            )
+        }
 
         collectionView.performBatchUpdates {
-            collectionView.insertItems(
-                at: newItems.indices.map {
-                    IndexPath(
-                        item: startIndex + $0,
-                        section: 0
-                    )
-                }
+            self.items.append(
+                contentsOf: newItems
             )
+            self.nextPage += 1
+            self.collectionView.insertItems(
+                at: indexPaths
+            )
+        } completion: {
+            [weak self] _ in
+            self?.isAppendingPage = false
         }
     }
 

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -182,7 +182,9 @@ final class ProfileImageCacheDemoViewController:
             let targetWidth = self?.gridItemWidth ?? 1
             let item = NSCollectionLayoutItem(
                 layoutSize: NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1),
+                    widthDimension: .fractionalWidth(
+                        1 / CGFloat(Constant.columnCount)
+                    ),
                     heightDimension: .fractionalHeight(1)
                 )
             )

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -15,14 +15,18 @@ final class ProfileImageCacheDemoViewController:
         static let itemSpacing: CGFloat = 1
         static let pageSize = 24
         static let paginationThreshold = 9
+        static let scrollPrefetchViewportCount: CGFloat = 1
     }
 
+    private let prefetchStrategy: ProfileImageCacheDemoPrefetchStrategy
     private let imagePrefetchSession =
         ProfileGridImagePrefetchSession()
     private var items: [ProfileImageCacheDemoItem] = []
     private var nextPage = 0
     private var isAppendingPage = false
     private var lastTargetWidth: CGFloat = 0
+    private var lastScrollOffsetY: CGFloat?
+    private var scrollPrefetchedPostIDs: Set<String> = []
 
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(
@@ -31,10 +35,13 @@ final class ProfileImageCacheDemoViewController:
         )
         collectionView.backgroundColor = .systemBackground
         collectionView.alwaysBounceVertical = true
-        collectionView.isPrefetchingEnabled = true
+        collectionView.isPrefetchingEnabled =
+            prefetchStrategy == .collectionViewDelegate
         collectionView.dataSource = self
         collectionView.delegate = self
-        collectionView.prefetchDataSource = self
+        if prefetchStrategy == .collectionViewDelegate {
+            collectionView.prefetchDataSource = self
+        }
         collectionView.register(
             ImageCell.self,
             forCellWithReuseIdentifier: ImageCell.reuseIdentifier
@@ -42,9 +49,24 @@ final class ProfileImageCacheDemoViewController:
         return collectionView
     }()
 
+    init(
+        prefetchStrategy: ProfileImageCacheDemoPrefetchStrategy
+    ) {
+        self.prefetchStrategy = prefetchStrategy
+        super.init(
+            nibName: nil,
+            bundle: nil
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:)는 지원하지 않습니다.")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "이미지 캐시 실험"
+        title = prefetchStrategy.title
         view.backgroundColor = .systemBackground
         configureCollectionView()
         configureNavigationItems()
@@ -108,8 +130,7 @@ final class ProfileImageCacheDemoViewController:
                 action: #selector(clearMemoryCache)
             ),
         ]
-        navigationItem.prompt =
-            "Picsum 무한 스크롤 · 프리패치 6개/동시 1개"
+        navigationItem.prompt = prefetchStrategy.prompt
     }
 
     private func appendNextPage() {
@@ -159,6 +180,112 @@ final class ProfileImageCacheDemoViewController:
             return
         }
         appendNextPage()
+    }
+
+    /// 스크롤 방향의 다음 한 화면을 프리패치합니다.
+    ///
+    /// `UICollectionViewDataSourcePrefetching`을 사용하지 않고, 현재 보이는 영역의
+    /// 높이를 기준으로 다음 화면 영역을 계산해 같은 세션에 전달합니다.
+    private func prefetchNextViewport(
+        for scrollView: UIScrollView
+    ) {
+        let adjustedInsets = collectionView.adjustedContentInset
+        let viewportHeight = max(
+            collectionView.bounds.height
+                - adjustedInsets.top
+                - adjustedInsets.bottom,
+            0
+        )
+        guard viewportHeight > 0 else {
+            return
+        }
+
+        let currentOffsetY = scrollView.contentOffset.y
+        let isScrollingDown = currentOffsetY >= (lastScrollOffsetY ?? currentOffsetY)
+        lastScrollOffsetY = currentOffsetY
+
+        let visibleRect = CGRect(
+            x: 0,
+            y: currentOffsetY + adjustedInsets.top,
+            width: collectionView.bounds.width,
+            height: viewportHeight
+        )
+        let targetRect = visibleRect.offsetBy(
+            dx: 0,
+            dy: viewportHeight
+                * Constant.scrollPrefetchViewportCount
+                * (isScrollingDown ? 1 : -1)
+        ).intersection(
+            CGRect(
+                origin: .zero,
+                size: collectionView.contentSize
+            )
+        )
+        guard !targetRect.isNull,
+              !targetRect.isEmpty
+        else {
+            return
+        }
+
+        let indexPaths = collectionView.collectionViewLayout
+            .layoutAttributesForElements(
+                in: targetRect
+            )?
+            .map(\.indexPath)
+            .filter {
+                items.indices.contains($0.item)
+            }
+            .sorted {
+                $0.item < $1.item
+            }
+            ?? []
+        prefetchScrollViewportItems(
+            at: indexPaths
+        )
+    }
+
+    private func prefetchScrollViewportItems(
+        at indexPaths: [IndexPath]
+    ) {
+        let requests = prefetchRequests(
+            at: indexPaths
+        )
+        let nextPostIDs = Set(
+            requests.map(\.postID)
+        )
+        let cancelledPostIDs = scrollPrefetchedPostIDs.subtracting(
+            nextPostIDs
+        )
+        imagePrefetchSession.cancelPrefetching(
+            postIDs: Array(cancelledPostIDs)
+        )
+        imagePrefetchSession.prefetch(
+            requests,
+            targetWidth: gridItemWidth
+        )
+        scrollPrefetchedPostIDs = nextPostIDs
+
+        if let furthestIndex = indexPaths.map(\.item).max() {
+            appendNextPageIfNeeded(
+                for: furthestIndex
+            )
+        }
+    }
+
+    private func prefetchRequests(
+        at indexPaths: [IndexPath]
+    ) -> [ProfileGridImagePrefetchRequest] {
+        indexPaths.compactMap {
+            indexPath in
+            guard items.indices.contains(indexPath.item) else {
+                return nil
+            }
+            let item = items[indexPath.item]
+            return ProfileGridImagePrefetchRequest(
+                postID: item.id,
+                imageURL: item.imageURL
+            )
+        }
     }
 
     private var gridItemWidth: CGFloat {
@@ -345,6 +472,17 @@ extension ProfileImageCacheDemoViewController:
             for: indexPath.item
         )
     }
+
+    func scrollViewDidScroll(
+        _ scrollView: UIScrollView
+    ) {
+        guard prefetchStrategy == .scrollViewport else {
+            return
+        }
+        prefetchNextViewport(
+            for: scrollView
+        )
+    }
 }
 
 extension ProfileImageCacheDemoViewController:
@@ -354,17 +492,12 @@ extension ProfileImageCacheDemoViewController:
         _ collectionView: UICollectionView,
         prefetchItemsAt indexPaths: [IndexPath]
     ) {
-        let requests: [ProfileGridImagePrefetchRequest] = indexPaths.compactMap {
-            indexPath in
-            guard items.indices.contains(indexPath.item) else {
-                return nil
-            }
-            let item = items[indexPath.item]
-            return ProfileGridImagePrefetchRequest(
-                postID: item.id,
-                imageURL: item.imageURL
-            )
+        guard prefetchStrategy == .collectionViewDelegate else {
+            return
         }
+        let requests = prefetchRequests(
+            at: indexPaths
+        )
         imagePrefetchSession.prefetch(
             requests,
             targetWidth: gridItemWidth
@@ -381,13 +514,12 @@ extension ProfileImageCacheDemoViewController:
         _ collectionView: UICollectionView,
         cancelPrefetchingForItemsAt indexPaths: [IndexPath]
     ) {
-        let postIDs: [String] = indexPaths.compactMap {
-            indexPath in
-            guard items.indices.contains(indexPath.item) else {
-                return nil
-            }
-            return items[indexPath.item].id
+        guard prefetchStrategy == .collectionViewDelegate else {
+            return
         }
+        let postIDs = prefetchRequests(
+            at: indexPaths
+        ).map(\.postID)
         imagePrefetchSession.cancelPrefetching(
             postIDs: postIDs
         )
@@ -448,6 +580,29 @@ private final class ImageCell: UICollectionViewCell {
                 targetWidth: targetWidth
             )
         )
+    }
+}
+
+enum ProfileImageCacheDemoPrefetchStrategy {
+    case collectionViewDelegate
+    case scrollViewport
+
+    var title: String {
+        switch self {
+        case .collectionViewDelegate:
+            "이미지 캐시 실험"
+        case .scrollViewport:
+            "이미지 캐시 실험 2"
+        }
+    }
+
+    var prompt: String {
+        switch self {
+        case .collectionViewDelegate:
+            "Picsum 무한 스크롤 · UIKit 프리패치 · 6개/동시 6개"
+        case .scrollViewport:
+            "Picsum 무한 스크롤 · 다음 한 화면 스크롤 프리패치 · 6개/동시 6개"
+        }
     }
 }
 

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -24,32 +24,6 @@ final class ProfileImageCacheDemoViewController:
     private var isAppendingPage = false
     private var lastTargetWidth: CGFloat = 0
 
-    private lazy var cacheControlStack: UIStackView = {
-        let stackView = UIStackView(
-            arrangedSubviews: [
-                makeCacheControlButton(
-                    title: "측정",
-                    imageName: "gauge.with.dots.needle.33percent",
-                    action: #selector(observeCacheClearMemory)
-                ),
-                makeCacheControlButton(
-                    title: "디스크",
-                    imageName: "externaldrive",
-                    action: #selector(clearDiskCache)
-                ),
-                makeCacheControlButton(
-                    title: "메모리",
-                    imageName: "memorychip",
-                    action: #selector(clearMemoryCache)
-                ),
-            ]
-        )
-        stackView.axis = .horizontal
-        stackView.spacing = 8
-        stackView.distribution = .fillEqually
-        return stackView
-    }()
-
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(
             frame: .zero,
@@ -73,7 +47,7 @@ final class ProfileImageCacheDemoViewController:
         title = "이미지 캐시 실험"
         view.backgroundColor = .systemBackground
         configureCollectionView()
-        updatePaginationPrompt()
+        configureNavigationItems()
         appendNextPage()
     }
 
@@ -95,32 +69,11 @@ final class ProfileImageCacheDemoViewController:
     }
 
     private func configureCollectionView() {
-        [
-            cacheControlStack,
-            collectionView,
-        ].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            view.addSubview($0)
-        }
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(collectionView)
         NSLayoutConstraint.activate([
-            cacheControlStack.topAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: 8
-            ),
-            cacheControlStack.leadingAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.leadingAnchor,
-                constant: 16
-            ),
-            cacheControlStack.trailingAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
-                constant: -16
-            ),
-            cacheControlStack.heightAnchor.constraint(
-                equalToConstant: 40
-            ),
             collectionView.topAnchor.constraint(
-                equalTo: cacheControlStack.bottomAnchor,
-                constant: 12
+                equalTo: view.safeAreaLayoutGuide.topAnchor
             ),
             collectionView.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor
@@ -134,32 +87,29 @@ final class ProfileImageCacheDemoViewController:
         ])
     }
 
-    private func makeCacheControlButton(
-        title: String,
-        imageName: String,
-        action: Selector
-    ) -> UIButton {
-        var configuration = UIButton.Configuration.tinted()
-        configuration.title = title
-        configuration.image = UIImage(
-            systemName: imageName
-        )
-        configuration.imagePadding = 4
-        configuration.cornerStyle = .medium
-
-        let button = UIButton(
-            configuration: configuration
-        )
-        button.titleLabel?.font = .systemFont(
-            ofSize: 13,
-            weight: .semibold
-        )
-        button.addTarget(
-            self,
-            action: action,
-            for: .touchUpInside
-        )
-        return button
+    private func configureNavigationItems() {
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                title: "측정",
+                style: .plain,
+                target: self,
+                action: #selector(observeCacheClearMemory)
+            ),
+            UIBarButtonItem(
+                title: "디스크",
+                style: .plain,
+                target: self,
+                action: #selector(clearDiskCache)
+            ),
+            UIBarButtonItem(
+                title: "메모리",
+                style: .plain,
+                target: self,
+                action: #selector(clearMemoryCache)
+            ),
+        ]
+        navigationItem.prompt =
+            "Picsum 무한 스크롤 · 프리패치 6개/동시 1개"
     }
 
     private func appendNextPage() {
@@ -199,7 +149,6 @@ final class ProfileImageCacheDemoViewController:
         } completion: {
             [weak self] _ in
             self?.isAppendingPage = false
-            self?.updatePaginationPrompt()
         }
     }
 
@@ -210,28 +159,6 @@ final class ProfileImageCacheDemoViewController:
             return
         }
         appendNextPage()
-    }
-
-    private func appendNextPageIfNeeded(
-        for scrollView: UIScrollView
-    ) {
-        let remainingScrollDistance =
-            scrollView.contentSize.height
-                - scrollView.contentOffset.y
-                - scrollView.bounds.height
-        let threshold = max(
-            gridItemWidth * 3,
-            300
-        )
-        guard remainingScrollDistance <= threshold else {
-            return
-        }
-        appendNextPage()
-    }
-
-    private func updatePaginationPrompt() {
-        navigationItem.prompt =
-            "Picsum \(items.count)장 · 아래로 스크롤하면 다음 24장 추가"
     }
 
     private var gridItemWidth: CGFloat {
@@ -414,14 +341,6 @@ extension ProfileImageCacheDemoViewController:
     ) {
         appendNextPageIfNeeded(
             for: indexPath.item
-        )
-    }
-
-    func scrollViewDidScroll(
-        _ scrollView: UIScrollView
-    ) {
-        appendNextPageIfNeeded(
-            for: scrollView
         )
     }
 }

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/ProfileImageCacheDemoViewController.swift
@@ -24,6 +24,32 @@ final class ProfileImageCacheDemoViewController:
     private var isAppendingPage = false
     private var lastTargetWidth: CGFloat = 0
 
+    private lazy var cacheControlStack: UIStackView = {
+        let stackView = UIStackView(
+            arrangedSubviews: [
+                makeCacheControlButton(
+                    title: "측정",
+                    imageName: "gauge.with.dots.needle.33percent",
+                    action: #selector(observeCacheClearMemory)
+                ),
+                makeCacheControlButton(
+                    title: "디스크",
+                    imageName: "externaldrive",
+                    action: #selector(clearDiskCache)
+                ),
+                makeCacheControlButton(
+                    title: "메모리",
+                    imageName: "memorychip",
+                    action: #selector(clearMemoryCache)
+                ),
+            ]
+        )
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(
             frame: .zero,
@@ -47,7 +73,7 @@ final class ProfileImageCacheDemoViewController:
         title = "이미지 캐시 실험"
         view.backgroundColor = .systemBackground
         configureCollectionView()
-        configureNavigationItems()
+        updatePaginationPrompt()
         appendNextPage()
     }
 
@@ -69,11 +95,32 @@ final class ProfileImageCacheDemoViewController:
     }
 
     private func configureCollectionView() {
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(collectionView)
+        [
+            cacheControlStack,
+            collectionView,
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
         NSLayoutConstraint.activate([
+            cacheControlStack.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor,
+                constant: 8
+            ),
+            cacheControlStack.leadingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leadingAnchor,
+                constant: 16
+            ),
+            cacheControlStack.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: -16
+            ),
+            cacheControlStack.heightAnchor.constraint(
+                equalToConstant: 40
+            ),
             collectionView.topAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.topAnchor
+                equalTo: cacheControlStack.bottomAnchor,
+                constant: 12
             ),
             collectionView.leadingAnchor.constraint(
                 equalTo: view.leadingAnchor
@@ -87,29 +134,32 @@ final class ProfileImageCacheDemoViewController:
         ])
     }
 
-    private func configureNavigationItems() {
-        navigationItem.rightBarButtonItems = [
-            UIBarButtonItem(
-                title: "측정",
-                style: .plain,
-                target: self,
-                action: #selector(observeCacheClearMemory)
-            ),
-            UIBarButtonItem(
-                title: "디스크",
-                style: .plain,
-                target: self,
-                action: #selector(clearDiskCache)
-            ),
-            UIBarButtonItem(
-                title: "메모리",
-                style: .plain,
-                target: self,
-                action: #selector(clearMemoryCache)
-            ),
-        ]
-        navigationItem.prompt =
-            "Picsum 무한 스크롤 · 프리패치 6개/동시 1개"
+    private func makeCacheControlButton(
+        title: String,
+        imageName: String,
+        action: Selector
+    ) -> UIButton {
+        var configuration = UIButton.Configuration.tinted()
+        configuration.title = title
+        configuration.image = UIImage(
+            systemName: imageName
+        )
+        configuration.imagePadding = 4
+        configuration.cornerStyle = .medium
+
+        let button = UIButton(
+            configuration: configuration
+        )
+        button.titleLabel?.font = .systemFont(
+            ofSize: 13,
+            weight: .semibold
+        )
+        button.addTarget(
+            self,
+            action: action,
+            for: .touchUpInside
+        )
+        return button
     }
 
     private func appendNextPage() {
@@ -149,6 +199,7 @@ final class ProfileImageCacheDemoViewController:
         } completion: {
             [weak self] _ in
             self?.isAppendingPage = false
+            self?.updatePaginationPrompt()
         }
     }
 
@@ -159,6 +210,28 @@ final class ProfileImageCacheDemoViewController:
             return
         }
         appendNextPage()
+    }
+
+    private func appendNextPageIfNeeded(
+        for scrollView: UIScrollView
+    ) {
+        let remainingScrollDistance =
+            scrollView.contentSize.height
+                - scrollView.contentOffset.y
+                - scrollView.bounds.height
+        let threshold = max(
+            gridItemWidth * 3,
+            300
+        )
+        guard remainingScrollDistance <= threshold else {
+            return
+        }
+        appendNextPage()
+    }
+
+    private func updatePaginationPrompt() {
+        navigationItem.prompt =
+            "Picsum \(items.count)장 · 아래로 스크롤하면 다음 24장 추가"
     }
 
     private var gridItemWidth: CGFloat {
@@ -341,6 +414,14 @@ extension ProfileImageCacheDemoViewController:
     ) {
         appendNextPageIfNeeded(
             for: indexPath.item
+        )
+    }
+
+    func scrollViewDidScroll(
+        _ scrollView: UIScrollView
+    ) {
+        appendNextPageIfNeeded(
+            for: scrollView
         )
     }
 }

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/SceneDelegate.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/SceneDelegate.swift
@@ -33,17 +33,32 @@ final class SceneDelegate:
             )
         profile.vc.title =
             "Profile V2"
-        profile.vc.navigationItem.leftBarButtonItem =
+        profile.vc.navigationItem.leftBarButtonItems = [
             UIBarButtonItem(
                 title: "이미지 실험",
                 primaryAction: UIAction {
                     [weak navigationController] _ in
                     navigationController?.pushViewController(
-                        ProfileImageCacheDemoViewController(),
+                        ProfileImageCacheDemoViewController(
+                            prefetchStrategy: .collectionViewDelegate
+                        ),
                         animated: true
                     )
                 }
-            )
+            ),
+            UIBarButtonItem(
+                title: "이미지 실험 2",
+                primaryAction: UIAction {
+                    [weak navigationController] _ in
+                    navigationController?.pushViewController(
+                        ProfileImageCacheDemoViewController(
+                            prefetchStrategy: .scrollViewport
+                        ),
+                        animated: true
+                    )
+                }
+            ),
+        ]
 
         profile.vm
             .onProfileImageTapped = {

--- a/Projects/Features/ProfileFeatureV2/Demo/Sources/SceneDelegate.swift
+++ b/Projects/Features/ProfileFeatureV2/Demo/Sources/SceneDelegate.swift
@@ -33,6 +33,17 @@ final class SceneDelegate:
             )
         profile.vc.title =
             "Profile V2"
+        profile.vc.navigationItem.leftBarButtonItem =
+            UIBarButtonItem(
+                title: "이미지 실험",
+                primaryAction: UIAction {
+                    [weak navigationController] _ in
+                    navigationController?.pushViewController(
+                        ProfileImageCacheDemoViewController(),
+                        animated: true
+                    )
+                }
+            )
 
         profile.vm
             .onProfileImageTapped = {
@@ -151,11 +162,11 @@ final class SceneDelegate:
 
         profile.vm.onImageTapped = {
             [weak navigationController]
-            post in
+            selection in
             Self.showNotice(
                 on: navigationController,
                 title: "게시물 선택",
-                message: post.postId
+                message: selection.post.postId
             )
         }
 

--- a/Projects/Features/ProfileFeatureV2/Interface/Sources/ProfilePresentable.swift
+++ b/Projects/Features/ProfileFeatureV2/Interface/Sources/ProfilePresentable.swift
@@ -2,6 +2,19 @@ import Core
 import Domain
 import UIKit
 
+public struct ProfilePostSelection {
+    public let post: Post
+    public let previewImage: UIImage?
+
+    public init(
+        post: Post,
+        previewImage: UIImage?
+    ) {
+        self.post = post
+        self.previewImage = previewImage
+    }
+}
+
 public protocol ProfileRouteTrigger {
     var onProfileImageTapped:
         ((String) -> Void)? { get set }
@@ -16,7 +29,7 @@ public protocol ProfileRouteTrigger {
     var onBirthdayEditButtonTapped:
         (() -> Void)? { get set }
     var onImageTapped:
-        ((Post) -> Void)? { get set }
+        ((ProfilePostSelection) -> Void)? { get set }
 }
 
 public typealias ProfileViewModelType =

--- a/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileGridImagePrefetchSession.swift
+++ b/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileGridImagePrefetchSession.swift
@@ -15,7 +15,7 @@ public struct ProfileGridImagePrefetchRequest: Hashable {
     }
 }
 
-/// UIKit의 프리패치 이벤트를 작은 순차 배치로 조절합니다.
+/// 그리드 프리패치 요청을 작은 순차 배치로 조절합니다.
 ///
 /// `ImagePrefetcher`는 인스턴스별로 동시 다운로드 제한을 관리하므로,
 /// 게시물마다 인스턴스를 만들면 전체 요청 수를 제한할 수 없습니다.
@@ -107,7 +107,7 @@ public final class ProfileGridImagePrefetchSession {
 
     public init(
         batchSize: Int = 6,
-        maxConcurrentDownloads: Int = 1
+        maxConcurrentDownloads: Int = 6
     ) {
         queue = ProfileGridImagePrefetchQueue(
             batchSize: batchSize
@@ -122,7 +122,7 @@ public final class ProfileGridImagePrefetchSession {
         stop()
     }
 
-    /// UIKit prefetch 이벤트가 전달한 가까운 그리드 이미지를 등록합니다.
+    /// 가까운 그리드 이미지를 프리패치 후보로 등록합니다.
     public func prefetch(
         _ requests: [ProfileGridImagePrefetchRequest],
         targetWidth: CGFloat
@@ -138,7 +138,7 @@ public final class ProfileGridImagePrefetchSession {
         startNextBatchIfNeeded()
     }
 
-    /// UIKit이 더 이상 필요하지 않다고 알린 이미지 후보를 제거합니다.
+    /// 더 이상 필요하지 않은 이미지 후보를 제거합니다.
     public func cancelPrefetching(
         postIDs: [String]
     ) {

--- a/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileGridImagePrefetchSession.swift
+++ b/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileGridImagePrefetchSession.swift
@@ -1,0 +1,236 @@
+import Kingfisher
+import UIKit
+
+/// 프로필 그리드에서 사용할 다운샘플 이미지 요청입니다.
+public struct ProfileGridImagePrefetchRequest: Hashable {
+    public let postID: String
+    public let imageURL: URL
+
+    public init(
+        postID: String,
+        imageURL: URL
+    ) {
+        self.postID = postID
+        self.imageURL = imageURL
+    }
+}
+
+/// UIKit의 프리패치 이벤트를 작은 순차 배치로 조절합니다.
+///
+/// `ImagePrefetcher`는 인스턴스별로 동시 다운로드 제한을 관리하므로,
+/// 게시물마다 인스턴스를 만들면 전체 요청 수를 제한할 수 없습니다.
+/// 이 큐는 화면마다 하나만 두고, 가까운 후보를 묶어 순서대로 처리합니다.
+final class ProfileGridImagePrefetchQueue {
+    private let batchSize: Int
+    private var pendingRequests: [ProfileGridImagePrefetchRequest] = []
+    private var activePostIDs: Set<String> = []
+
+    init(
+        batchSize: Int = 6
+    ) {
+        self.batchSize = max(batchSize, 1)
+    }
+
+    var hasActiveBatch: Bool {
+        !activePostIDs.isEmpty
+    }
+
+    func enqueue(
+        _ requests: [ProfileGridImagePrefetchRequest]
+    ) {
+        let knownPostIDs =
+            activePostIDs.union(
+                Set(
+                    pendingRequests.map(\.postID)
+                )
+            )
+        let newRequests = requests.filter {
+            !knownPostIDs.contains($0.postID)
+        }
+        pendingRequests.append(
+            contentsOf: newRequests
+        )
+    }
+
+    func nextBatch() -> [ProfileGridImagePrefetchRequest] {
+        guard !hasActiveBatch,
+              !pendingRequests.isEmpty
+        else {
+            return []
+        }
+
+        let batch = Array(
+            pendingRequests.prefix(batchSize)
+        )
+        pendingRequests.removeFirst(
+            batch.count
+        )
+        activePostIDs = Set(
+            batch.map(\.postID)
+        )
+        return batch
+    }
+
+    /// - Returns: 현재 실행 중인 배치에 계속 유지할 요청이 남았는지 여부입니다.
+    func cancel(
+        postIDs: Set<String>
+    ) -> Bool {
+        pendingRequests.removeAll {
+            postIDs.contains($0.postID)
+        }
+        activePostIDs.subtract(
+            postIDs
+        )
+        return !activePostIDs.isEmpty
+    }
+
+    func finishActiveBatch() {
+        activePostIDs.removeAll()
+    }
+
+    func reset() {
+        pendingRequests.removeAll()
+        activePostIDs.removeAll()
+    }
+}
+
+/// 프로필 그리드의 스크롤 기반 이미지 프리패치 세션입니다.
+///
+/// 셀 렌더링과 같은 다운샘플러 및 백그라운드 디코더를 사용하고,
+/// 원본은 디스크 캐시에 보관해 상세 화면에서 다시 사용할 수 있게 합니다.
+public final class ProfileGridImagePrefetchSession {
+    private let queue: ProfileGridImagePrefetchQueue
+    private let maxConcurrentDownloads: Int
+    private var prefetcher: ImagePrefetcher?
+    private var activeBatchID: UUID?
+    private var targetWidth: CGFloat?
+
+    public init(
+        batchSize: Int = 6,
+        maxConcurrentDownloads: Int = 1
+    ) {
+        queue = ProfileGridImagePrefetchQueue(
+            batchSize: batchSize
+        )
+        self.maxConcurrentDownloads = max(
+            maxConcurrentDownloads,
+            1
+        )
+    }
+
+    deinit {
+        stop()
+    }
+
+    /// UIKit prefetch 이벤트가 전달한 가까운 그리드 이미지를 등록합니다.
+    public func prefetch(
+        _ requests: [ProfileGridImagePrefetchRequest],
+        targetWidth: CGFloat
+    ) {
+        guard !requests.isEmpty else {
+            return
+        }
+
+        updateTargetWidthIfNeeded(
+            targetWidth
+        )
+        queue.enqueue(requests)
+        startNextBatchIfNeeded()
+    }
+
+    /// UIKit이 더 이상 필요하지 않다고 알린 이미지 후보를 제거합니다.
+    public func cancelPrefetching(
+        postIDs: [String]
+    ) {
+        guard !postIDs.isEmpty else {
+            return
+        }
+
+        let hasActiveRequests = queue.cancel(
+            postIDs: Set(postIDs)
+        )
+        guard !hasActiveRequests else {
+            return
+        }
+
+        cancelActiveBatch()
+        startNextBatchIfNeeded()
+    }
+
+    /// 화면을 벗어나거나 캐시를 비울 때 실행 중인 프리패치를 정리합니다.
+    public func stop() {
+        prefetcher?.stop()
+        prefetcher = nil
+        activeBatchID = nil
+        queue.reset()
+    }
+
+    private func updateTargetWidthIfNeeded(
+        _ newTargetWidth: CGFloat
+    ) {
+        let normalizedWidth = max(
+            newTargetWidth,
+            1
+        )
+        guard targetWidth != normalizedWidth else {
+            return
+        }
+
+        stop()
+        targetWidth = normalizedWidth
+    }
+
+    private func startNextBatchIfNeeded() {
+        guard prefetcher == nil,
+              let targetWidth
+        else {
+            return
+        }
+
+        let batch = queue.nextBatch()
+        guard !batch.isEmpty else {
+            return
+        }
+
+        let batchID = UUID()
+        let prefetcher = ImagePrefetcher(
+            urls: batch.map(\.imageURL),
+            options: ProfileGridImageRequest.prefetchOptions(
+                targetWidth: targetWidth
+            ),
+            completionHandler: {
+                [weak self] _, _, _ in
+                DispatchQueue.main.async {
+                    self?.finishBatch(
+                        identifiedBy: batchID
+                    )
+                }
+            }
+        )
+        prefetcher.maxConcurrentDownloads =
+            maxConcurrentDownloads
+        activeBatchID = batchID
+        self.prefetcher = prefetcher
+        prefetcher.start()
+    }
+
+    private func cancelActiveBatch() {
+        prefetcher?.stop()
+        prefetcher = nil
+        activeBatchID = nil
+        queue.finishActiveBatch()
+    }
+
+    private func finishBatch(
+        identifiedBy batchID: UUID
+    ) {
+        guard activeBatchID == batchID else {
+            return
+        }
+
+        prefetcher = nil
+        activeBatchID = nil
+        queue.finishActiveBatch()
+        startNextBatchIfNeeded()
+    }
+}

--- a/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfilePostComponent.swift
+++ b/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfilePostComponent.swift
@@ -4,8 +4,8 @@ import DSKit
 import Kingfisher
 import UIKit
 
-enum ProfilePostImageRequest {
-    static func options(
+public enum ProfileGridImageRequest {
+    public static func options(
         targetWidth: CGFloat
     ) -> KingfisherOptionsInfo {
         let width = max(
@@ -27,6 +27,16 @@ enum ProfilePostImageRequest {
                 UIScreen.main.scale
             ),
             .cacheOriginalImage,
+        ]
+    }
+
+    static func prefetchOptions(
+        targetWidth: CGFloat
+    ) -> KingfisherOptionsInfo {
+        options(
+            targetWidth: targetWidth
+        ) + [
+            .alsoPrefetchToMemory,
         ]
     }
 }
@@ -167,11 +177,15 @@ final class ProfilePostContentView:
         imageView.kf.setImage(
             with: url,
             options:
-                ProfilePostImageRequest
+                ProfileGridImageRequest
                     .options(
                         targetWidth:
                             item.targetWidth
                     )
         )
+    }
+
+    var renderedImage: UIImage? {
+        imageView.image
     }
 }

--- a/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileViewController.swift
+++ b/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileViewController.swift
@@ -20,11 +20,6 @@ final class ProfileViewController:
         static let itemSpacing: CGFloat = 1
     }
 
-    private struct ActiveImagePrefetch {
-        let id: UUID
-        let prefetcher: ImagePrefetcher
-    }
-
     private let customView =
         ProfileView()
     private let viewModel:
@@ -34,15 +29,15 @@ final class ProfileViewController:
     private let reloadRelay =
         PublishRelay<Void>()
     private let imageTappedRelay =
-        PublishRelay<Post>()
+        PublishRelay<ProfilePostSelection>()
     private let nicknameEditTappedRelay =
         PublishRelay<Void>()
     private let birthdayEditTappedRelay =
         PublishRelay<Void>()
     private var imageURLsByPostID:
         [String: URL] = [:]
-    private var activeImagePrefetches:
-        [String: ActiveImagePrefetch] = [:]
+    private let imagePrefetchSession =
+        ProfileGridImagePrefetchSession()
 
     private lazy var adapter:
         CollectionViewAdapter = {
@@ -97,11 +92,7 @@ final class ProfileViewController:
     }
 
     deinit {
-        activeImagePrefetches
-            .values
-            .forEach {
-                $0.prefetcher.stop()
-            }
+        imagePrefetchSession.stop()
     }
 
     override func loadView() {
@@ -338,10 +329,17 @@ final class ProfileViewController:
                         )
                         .pressedEffect(scale: 0.98)
                         .onTouch {
-                            [weak self] in
+                            [weak self] content in
                             self?
                                 .imageTappedRelay
-                                .accept(post)
+                                .accept(
+                                    ProfilePostSelection(
+                                        post: post,
+                                        previewImage:
+                                            content
+                                                .renderedImage
+                                    )
+                                )
                         }
                     }
                 }
@@ -442,7 +440,8 @@ final class ProfileViewController:
     private func updateImageURLLookup(
         _ posts: [Post]
     ) {
-        imageURLsByPostID =
+        let previousImageURLs = imageURLsByPostID
+        let updatedImageURLs: [String: URL] =
             posts.reduce(into: [:]) {
                 result, post in
                 guard
@@ -456,103 +455,53 @@ final class ProfileViewController:
                 result[post.postId] =
                     url
             }
+        imageURLsByPostID = updatedImageURLs
 
-        let currentPostIDs =
-            Set(
-                imageURLsByPostID.keys
-            )
-        let removedPostIDs =
-            activeImagePrefetches
-                .keys
-                .filter {
-                    !currentPostIDs
-                        .contains($0)
-                }
-        cancelImagePrefetching(
-            forPostIDs:
-                removedPostIDs
+        let invalidatedPostIDs: [String] = Set(
+            previousImageURLs.keys
         )
+        .union(
+            Set(updatedImageURLs.keys)
+        )
+        .filter {
+            previousImageURLs[$0] != updatedImageURLs[$0]
+        }
+        imagePrefetchSession.cancelPrefetching(
+            postIDs: invalidatedPostIDs
+        )
+
     }
 
     private func prefetchImages(
         for items:
             [CollectionViewPrefetchItem]
     ) {
-        for postID in profilePostIDs(
+        let requests = profilePostIDs(
             from: items
-        ) {
-            guard
-                activeImagePrefetches[
-                    postID
-                ] == nil,
-                let imageURL =
-                    imageURLsByPostID[
-                        postID
-                    ]
-            else {
-                continue
-            }
-
-            let requestID = UUID()
-            let prefetcher =
-                ImagePrefetcher(
-                    urls: [imageURL],
-                    options:
-                        ProfilePostImageRequest
-                            .options(
-                                targetWidth:
-                                    profilePostTargetWidth
-                            ),
-                    completionHandler: {
-                        [weak self] _, _, _ in
-                        guard
-                            self?
-                                .activeImagePrefetches[
-                                    postID
-                                ]?.id
-                                == requestID
-                        else {
-                            return
-                        }
-                        self?
-                            .activeImagePrefetches[
-                                postID
-                            ] = nil
-                    }
+        )
+        .compactMap { postID in
+            imageURLsByPostID[postID].map {
+                ProfileGridImagePrefetchRequest(
+                    postID: postID,
+                    imageURL: $0
                 )
-            activeImagePrefetches[
-                postID
-            ] = ActiveImagePrefetch(
-                id: requestID,
-                prefetcher: prefetcher
-            )
-            prefetcher.start()
+            }
         }
+        imagePrefetchSession.prefetch(
+            requests,
+            targetWidth: profilePostTargetWidth
+        )
     }
 
     private func cancelImagePrefetching(
         for items:
             [CollectionViewPrefetchItem]
     ) {
-        cancelImagePrefetching(
-            forPostIDs:
-                profilePostIDs(
-                    from: items
-                )
+        imagePrefetchSession.cancelPrefetching(
+            postIDs: profilePostIDs(
+                from: items
+            )
         )
-    }
-
-    private func cancelImagePrefetching(
-        forPostIDs postIDs: [String]
-    ) {
-        for postID in postIDs {
-            activeImagePrefetches
-                .removeValue(
-                    forKey: postID
-                )?
-                .prefetcher
-                .stop()
-        }
     }
 
     private func profilePostIDs(

--- a/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileViewModel.swift
+++ b/Projects/Features/ProfileFeatureV2/Sources/Profile/ProfileViewModel.swift
@@ -19,7 +19,7 @@ final class ProfileViewModel:
     var onSettingButtonTapped:
         (() -> Void)?
     var onImageTapped:
-        ((Post) -> Void)?
+        ((ProfilePostSelection) -> Void)?
 
     struct Input {
         let profileImageTapped:
@@ -33,7 +33,7 @@ final class ProfileViewModel:
         let settingTapped:
             Observable<Void>
         let imageTapped:
-            Observable<Post>
+            Observable<ProfilePostSelection>
         let reload:
             Observable<Void>
         let viewWillAppear:
@@ -203,8 +203,8 @@ final class ProfileViewModel:
 
         input.imageTapped
             .bind(with: self) {
-                owner, post in
-                owner.onImageTapped?(post)
+                owner, selection in
+                owner.onImageTapped?(selection)
             }
             .disposed(by: disposeBag)
 

--- a/Projects/Features/ProfileFeatureV2/Tests/Sources/ProfileGridImagePrefetchQueueTests.swift
+++ b/Projects/Features/ProfileFeatureV2/Tests/Sources/ProfileGridImagePrefetchQueueTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import ProfileFeatureV2
+
+final class ProfileGridImagePrefetchQueueTests:
+    XCTestCase
+{
+    func testQueueProcessesRequestsInBoundedSequentialBatches() {
+        let queue = ProfileGridImagePrefetchQueue(
+            batchSize: 2
+        )
+        queue.enqueue(
+            [
+                request(id: "one"),
+                request(id: "two"),
+                request(id: "three"),
+            ]
+        )
+
+        XCTAssertEqual(
+            queue.nextBatch().map(\.postID),
+            [
+                "one",
+                "two",
+            ]
+        )
+        XCTAssertTrue(
+            queue.nextBatch().isEmpty
+        )
+
+        queue.finishActiveBatch()
+
+        XCTAssertEqual(
+            queue.nextBatch().map(\.postID),
+            ["three"]
+        )
+    }
+
+    func testQueueRemovesCancelledPendingRequests() {
+        let queue = ProfileGridImagePrefetchQueue(
+            batchSize: 1
+        )
+        queue.enqueue(
+            [
+                request(id: "one"),
+                request(id: "two"),
+                request(id: "three"),
+            ]
+        )
+        _ = queue.nextBatch()
+
+        XCTAssertTrue(
+            queue.cancel(
+                postIDs: ["two"]
+            )
+        )
+
+        queue.finishActiveBatch()
+
+        XCTAssertEqual(
+            queue.nextBatch().map(\.postID),
+            ["three"]
+        )
+    }
+
+    func testQueueSignalsWhenAllActiveRequestsAreCancelled() {
+        let queue = ProfileGridImagePrefetchQueue()
+        queue.enqueue(
+            [request(id: "one")]
+        )
+        _ = queue.nextBatch()
+
+        XCTAssertFalse(
+            queue.cancel(
+                postIDs: ["one"]
+            )
+        )
+    }
+
+    private func request(
+        id: String
+    ) -> ProfileGridImagePrefetchRequest {
+        ProfileGridImagePrefetchRequest(
+            postID: id,
+            imageURL: URL(
+                string: "https://example.com/\(id).jpg"
+            )!
+        )
+    }
+}


### PR DESCRIPTION
## 💡 PR 유형

- [x] Feature: 기능 추가
- [ ] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [x] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- 일일 사진 업로드만 JPEG 품질 `1.0`으로 인코딩하고, 프로필 이미지는 기존 `0.8`을 명시적으로 유지했습니다.
- 프로필 그리드의 UIKit 프리패치 이벤트를 화면 단위 세션으로 모아 최대 6개 후보를 한 배치로 관리하고, 배치 안에서는 최대 6개를 동시에 다운로드합니다.
- 셀과 프리패치에 같은 다운샘플링·백그라운드 디코딩 옵션을 적용하고 원본을 캐시합니다. 상세 화면은 셀 썸네일을 즉시 보인 뒤 원본을 로드합니다.
- `ProfileFeatureV2Demo`에 Picsum 기반 무한 스크롤 이미지 실험 화면 두 가지를 추가했습니다. 첫 화면은 UIKit 프리패치 델리게이트, 두 번째 화면은 스크롤 방향의 다음 한 화면 높이를 계산하는 프리패치 방식입니다. 두 화면 모두 메모리/디스크 캐시 삭제와 캐시 삭제 전후 `phys_footprint` 측정을 제공합니다.
- 이미지 실험 첫 페이지의 데이터 변경과 UICollectionView 삽입을 같은 batch update 안에서 처리해 화면 진입 시 크래시를 수정했습니다.
- 이미지 실험의 compositional layout item 너비를 3분의 1로 수정해 한 행에 3장의 그리드로 표시합니다.
- 프리패치 큐의 배치, 취소, 종료 동작 단위 테스트를 추가했습니다.

## 🚨 관련 이슈

- Closes #83

## 🎨 스크린샷

| 기능 | 스크린샷 |
| :--: | :--: |
| Profile V2 Demo 진입 | 시뮬레이터에서 `이미지 실험` 버튼 노출과 프로필 그리드 로딩을 확인했습니다. |

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- `compressionQuality = 1.0`은 JPEG 최대 품질 재인코딩이며, 원본 파일 바이트와 메타데이터를 그대로 보존하는 방식은 아닙니다.
- 캐시 삭제 후에도 visible 이미지, allocator, OS의 회수 시점 때문에 프로세스 메모리가 즉시 줄지 않거나 변동할 수 있음을 데모에서 측정값으로 확인합니다.
- 검증: `tuist generate --no-open`, `xcodebuild test -scheme ProfileFeatureV2`, `xcodebuild build -scheme ProfileFeatureV2Demo`, `xcodebuild test -scheme App`

## 🖼️ 프로필 이미지 처리 방식

프로필 이미지는 서버에 원본 한 장만 저장하고, 클라이언트가 화면 목적에 맞게 처리합니다. 서버 썸네일을 별도로 만들지 않아도 그리드 스크롤 성능과 상세 이미지 품질을 함께 유지할 수 있습니다.

```text
서버 imageURL 하나
  ├─ 프로필 그리드: 다운샘플 이미지
  │    └─ 프리패치 이벤트 또는 스크롤 화면 비율 → 화면 단위 큐 → Kingfisher 캐시
  └─ 상세 화면: 원본 크기 요청
       └─ 그리드 이미지를 먼저 표시한 뒤 원본으로 교체
```

### 서버와 그리드

- 일상 사진은 JPEG 품질 `1.0`으로 인코딩해 업로드합니다. 프로필 이미지는 기존 품질 `0.8`을 유지합니다.
- 프로필 그리드는 같은 `imageURL`을 사용하되, 가로 `W`, 세로 `W × 1.5`인 세로형 셀의 목표 크기에 맞춰 다운샘플링합니다. `1.5`는 압축률이 아니라 그리드 셀의 세로 비율입니다.
- 셀은 `backgroundDecode`, 화면 scale 적용, `cacheOriginalImage`를 사용합니다. 그리드용 이미지는 작게 디코딩하고, 원본은 캐시에 남겨 상세 화면에서 재사용합니다.

### 프리패치와 취소

- 기본 프로필 그리드는 `UICollectionViewDataSourcePrefetching` 이벤트에서 시작합니다. UIKit이 곧 화면에 들어올 셀을 알려주면, 화면당 하나의 프리패치 세션이 `postID`와 URL을 큐에 넣습니다.
- 데모의 `이미지 실험 2`는 UIKit 프리패치 델리게이트를 등록하지 않습니다. `scrollViewDidScroll`에서 현재 보이는 영역 높이만큼 스크롤 방향 앞쪽을 계산하고, 그 한 화면 영역의 셀만 같은 세션에 전달합니다.
- 세션은 중복 요청을 제거하고 최대 6개를 한 배치로 처리합니다. 배치 안에서는 최대 6개를 동시에 다운로드합니다. 6개는 캐시 총량이 아니라 가까운 후보를 한 번에 관리하는 단위입니다.
- UIKit이 프리패치 취소를 알리거나 스크롤 기반 실험의 대상 화면이 바뀌면 아직 시작하지 않은 요청을 큐에서 제거합니다. 실행 중인 배치에 필요한 요청이 하나도 남지 않으면 해당 배치도 중단합니다. 화면 폭이 바뀌면 이전 크기의 결과가 섞이지 않도록 세션을 초기화합니다.

### 상세 화면 전환

- 사용자가 셀을 탭하면 현재 셀에 표시된 다운샘플 이미지를 상세 화면의 초기 이미지로 전달합니다.
- 상세 화면은 초기 이미지를 즉시 표시한 상태에서 같은 URL의 원본을 비동기로 요청합니다. 원본 캐시가 있으면 캐시를 사용하고, 없으면 네트워크에서 가져옵니다.
- 원본을 준비하면 기존 이미지를 교체합니다. 상세 화면 진입 직후 빈 화면이나 깜빡임을 줄이는 방식입니다.

결과적으로 그리드는 필요한 크기만 빠르게 보여주고, 상세 화면은 즉시 표시한 뒤 원본 품질로 전환합니다. 프리패치는 셀마다 따로 만들지 않고 화면 단위 세션에서 제한합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 프로필 게시물 이미지를 선택하면 미리보기 이미지와 함께 상세 화면이 열립니다.
  - 프로필 이미지 그리드에 이미지 프리패칭을 적용해 스크롤 및 로딩 경험을 개선했습니다.
  - 이미지 업로드 시 압축 품질을 지정할 수 있습니다.
  - 이미지 캐시와 메모리 사용량을 확인할 수 있는 데모 화면을 추가했습니다.

- **개선 사항**
  - 상세 화면에서 다운로드 전 선택한 이미지가 먼저 표시됩니다.
  - 이미지 캐시 처리와 프리패칭 취소 동작을 안정화했습니다.

- **테스트**
  - 이미지 프리패칭 큐의 배치 처리와 취소 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
