### PR TITLE
[#85] 의존성 업데이트 워크플로우가 정상 변경을 실패로 처리하는 문제

### DIFF
--- a/.github/workflows/dependency-updater.yaml
+++ b/.github/workflows/dependency-updater.yaml
@@ -86,7 +86,7 @@ jobs:
           set -euo pipefail
           tuist install
           tuist generate --no-open
-          git diff --exit-code --check
+          git diff --check
           if git diff --quiet -- Tuist/Package.swift Tuist/Package.resolved; then
             echo "::error::The updater selected a version but Tuist did not change a tracked dependency file."
             exit 1


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- 의존성 업데이트 후 정상적으로 발생한 diff가 실패로 처리되지 않도록 `git diff --exit-code --check`를 `git diff --check`로 변경했습니다.
- `Tuist/Package.swift`와 `Tuist/Package.resolved`의 변경 여부는 기존 `git diff --quiet` 검증으로 유지했습니다.

## 🚨 관련 이슈

- Closes #85

## 🎨 스크린샷

해당 없음. GitHub Actions 자동화 작업입니다.

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 확인한 범위에서 정상적으로 동작하나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- `python3 -m unittest scripts/tests/test_update_ios_dependencies.py`를 실행했습니다. (9 tests passed)
- `git diff --check`를 실행했습니다.
- 전체 GitHub Actions 실행은 PR 생성 후 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선**
  - 의존성 파일 변경 여부와 관계없이 변경 사항의 공백 오류를 일관되게 검증하도록 자동화된 품질 검사를 조정했습니다.
  - 불필요한 조건을 제거해 검사 결과가 더욱 명확해지고, 사소한 형식 오류를 보다 안정적으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->