### PR TITLE
[#87] 의존성 업데이트 워크플로우의 Simulator UUID 추출 오류 수정

### DIFF
--- a/.github/workflows/dependency-updater.yaml
+++ b/.github/workflows/dependency-updater.yaml
@@ -99,7 +99,7 @@ jobs:
           set -euo pipefail
           UDID=$(xcrun simctl list devices available | \
             grep "iOS ${SIMULATOR_OS}" -A 20 | \
-            grep "^ *${SIMULATOR_NAME} (" | head -n 1 | sed -E 's/.*\\(([A-F0-9-]+)\\).*/\\1/')
+            grep "^ *${SIMULATOR_NAME} (" | head -n 1 | sed -nE 's/.*\(([A-F0-9-]+)\).*/\1/p')
           if [[ -z "$UDID" ]]; then
             echo "::error::${SIMULATOR_NAME} (iOS ${SIMULATOR_OS}) simulator not found."
             exit 1


### PR DESCRIPTION
## 💡 PR 유형

- [ ] Feature: 기능 추가
- [x] Fix: 일반 버그 수정
- [ ] Hotfix: 긴급 버그 수정
- [ ] Chore: 환경 설정 및 기타 작업
- [ ] Refactor: 코드 개선
- [ ] Test: 테스트 코드 작성
- [ ] Docs: 문서 작성 및 수정

## ✏️ 변경 사항

- Simulator UUID 추출식의 중복 이스케이프를 제거해 `SIM_UDID`에 UUID만 저장하도록 수정했습니다.
- `sed -nE`를 사용해 정규식이 일치하지 않을 때 디바이스 원본 행이 출력되지 않도록 했습니다.

## 🚨 관련 이슈

- Closes #87

## 🎨 스크린샷

해당 없음. GitHub Actions 자동화 작업입니다.

## ✅ 체크리스트

- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [ ] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 확인한 범위에서 정상적으로 동작하나요?
- [x] 관련 이슈 번호를 작성했나요?

## 🔥 추가 설명

- UUID 추출 명령에 CI 로그의 Simulator 행을 입력해 UUID만 출력되는 것을 확인했습니다.
- `python3 -m unittest scripts/tests/test_update_ios_dependencies.py`를 실행했습니다. (9 tests passed)
- `git diff --check`를 실행했습니다.
- 실제 Simulator 빌드·테스트는 PR CI에서 확인이 필요합니다.
