### PR TITLE
[#90] 의존성 변경 시 CI 빌드 캐시를 무효화한다

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,13 +78,14 @@ jobs:
           sudo xcode-select -s "/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
           xcodebuild -version
 
+      # Exact-key-only caches prevent artifacts from a different dependency graph
+      # from being restored after Tuist/Package.resolved changes.
       # SwiftPM Cache
       - name: Cache SwiftPM
         uses: actions/cache@v4
         with:
           path: ~/Library/Caches/org.swift.swiftpm
-          key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: spm-${{ runner.os }}-
+          key: spm-v2-${{ runner.os }}-${{ hashFiles('Tuist/Package.swift', 'Tuist/Package.resolved') }}
 
       # Tuist Cache
       - name: Cache Tuist
@@ -94,17 +95,14 @@ jobs:
             ~/.tuist/Dependencies
             ~/.tuist/Cache
             Tuist/Dependencies/.build
-          key: tuist-${{ runner.os }}-${{ hashFiles('Tuist/Dependencies.swift') }}
-          restore-keys: tuist-${{ runner.os }}-
+          key: tuist-v2-${{ runner.os }}-${{ hashFiles('Tuist/Package.swift', 'Tuist/Package.resolved') }}
 
       # DerivedData Cache
       - name: Cache DerivedData
         uses: actions/cache@v4
         with:
           path: DerivedData
-          key: deriveddata-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.module }}-${{ hashFiles('Tuist.swift', 'Workspace.swift', 'Tuist/Package.swift', 'Projects/**/Project.swift') }}
-          restore-keys: |
-            deriveddata-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.module }}-
+          key: deriveddata-v2-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ matrix.module }}-${{ hashFiles('Tuist.swift', 'Workspace.swift', 'Tuist/Package.swift', 'Tuist/Package.resolved', 'Projects/**/Project.swift') }}
 
       - name: Set up Mise and Tuist
         uses: jdx/mise-action@v4
@@ -118,15 +116,7 @@ jobs:
 
       # Simulator UUID Resolve
       - name: Resolve Simulator UUID
-        run: |
-          UDID=$(xcrun simctl list devices available | \
-            grep "iOS ${SIMULATOR_OS}" -A 20 | \
-            grep "^ *${SIMULATOR_NAME} (" | head -n 1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-          if [ -z "$UDID" ]; then
-            echo "${SIMULATOR_NAME} (iOS ${SIMULATOR_OS}) simulator not found"
-            exit 1
-          fi
-          echo "SIM_UDID=$UDID" >> "$GITHUB_ENV"
+        run: scripts/resolve_simulator_udid.sh
 
       # 1. Build For Testing (VM 내부)
       - name: Build For Testing

--- a/.github/workflows/dependency-updater.yaml
+++ b/.github/workflows/dependency-updater.yaml
@@ -94,17 +94,7 @@ jobs:
 
       - name: Resolve Simulator UUID
         if: steps.update.outputs.has_changes == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
-        shell: bash
-        run: |
-          set -euo pipefail
-          UDID=$(xcrun simctl list devices available | \
-            grep "iOS ${SIMULATOR_OS}" -A 20 | \
-            grep "^ *${SIMULATOR_NAME} (" | head -n 1 | sed -nE 's/.*\(([A-F0-9-]+)\).*/\1/p')
-          if [[ -z "$UDID" ]]; then
-            echo "::error::${SIMULATOR_NAME} (iOS ${SIMULATOR_OS}) simulator not found."
-            exit 1
-          fi
-          echo "SIM_UDID=$UDID" >> "$GITHUB_ENV"
+        run: scripts/resolve_simulator_udid.sh
 
       - name: Build and test Core, Data, and App
         if: steps.update.outputs.has_changes == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)

--- a/scripts/resolve_simulator_udid.sh
+++ b/scripts/resolve_simulator_udid.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# Finds an available simulator UUID and writes `SIM_UDID=<UUID>` to GITHUB_ENV.
+#
+# Required variables:
+# - SIMULATOR_NAME: device name, for example "iPhone 16"
+# - SIMULATOR_OS: iOS runtime version, for example "26.2"
+# - GITHUB_ENV: destination file for SIM_UDID (GitHub Actions provides this)
+#
+# GitHub Actions:
+#   run: scripts/resolve_simulator_udid.sh
+#
+# Local macOS usage (with the selected Simulator runtime installed):
+#   ENV_FILE="$(mktemp)"
+#   SIMULATOR_NAME="iPhone 16" SIMULATOR_OS="26.2" GITHUB_ENV="$ENV_FILE" scripts/resolve_simulator_udid.sh
+#   source "$ENV_FILE" && export SIM_UDID
+#   rm "$ENV_FILE"
+
 set -euo pipefail
 
 : "${SIMULATOR_NAME:?SIMULATOR_NAME must be set}"

--- a/scripts/resolve_simulator_udid.sh
+++ b/scripts/resolve_simulator_udid.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${SIMULATOR_NAME:?SIMULATOR_NAME must be set}"
+: "${SIMULATOR_OS:?SIMULATOR_OS must be set}"
+: "${GITHUB_ENV:?GITHUB_ENV must be set}"
+
+if ! udid="$(
+  xcrun simctl list devices available |
+    grep -A 20 "iOS ${SIMULATOR_OS}" |
+    grep -m 1 "^ *${SIMULATOR_NAME} (" |
+    sed -nE 's/.*\(([A-F0-9-]+)\).*/\1/p'
+)"; then
+  echo "::error::${SIMULATOR_NAME} (iOS ${SIMULATOR_OS}) simulator not found."
+  exit 1
+fi
+
+if [[ ! "$udid" =~ ^[A-F0-9-]{36}$ ]]; then
+  echo "::error::Could not extract a valid UUID for ${SIMULATOR_NAME} (iOS ${SIMULATOR_OS})."
+  exit 1
+fi
+
+echo "SIM_UDID=$udid" >> "$GITHUB_ENV"


### PR DESCRIPTION
## 💡 PR 유형

- [x] Fix

## ✏️ 변경 사항

- 의존성 lockfile이 바뀌면 SwiftPM, Tuist, DerivedData 캐시가 새 키를 사용하도록 변경했습니다.
- 넓은 `restore-keys` fallback을 제거해 다른 의존성 그래프의 빌드 산출물을 복원하지 않습니다.
- 두 CI 워크플로에서 Simulator UUID를 같은 검증 스크립트로 추출합니다.

## 🚨 관련 이슈

- Closes #90

## 📸 스크린샷

해당 없음

## ✅ 체크리스트

- [x] 프로젝트 컨벤션을 확인했습니다.
- [x] 변경 범위를 확인했습니다.
- [x] 관련 이슈를 등록했습니다.

## 🧪 검증

- `bash -n scripts/resolve_simulator_udid.sh`
- 가짜 `xcrun` 환경에서 UUID 추출 성공·실패 경로 검증
- 두 GitHub Actions YAML 파싱
- `python3 -m unittest scripts/tests/test_update_ios_dependencies.py` (9 tests)
- `git diff --check`

GitHub Actions 전체 실행은 이 PR에서 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 빌드 및 테스트 자동화에서 캐시를 더 정확하게 관리해 실행 속도와 안정성을 개선했습니다.
  * 지정된 iOS 시뮬레이터를 자동으로 식별하고 테스트 환경에 적용하도록 개선했습니다.
  * 시뮬레이터를 찾지 못하거나 식별 정보가 올바르지 않은 경우 오류를 명확히 표시하도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->